### PR TITLE
[TOG-11] feat: 로그인 및 카카오 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     implementation 'io.hypersistence:hypersistence-utils-hibernate-63:3.9.10'
 
+
     // jwt
     implementation "io.jsonwebtoken:jjwt-api:${jjwtVersion}"
     runtimeOnly "io.jsonwebtoken:jjwt-gson:${jjwtVersion}"

--- a/src/main/java/com/together/server/api/auth/AuthController.java
+++ b/src/main/java/com/together/server/api/auth/AuthController.java
@@ -1,20 +1,22 @@
 package com.together.server.api.auth;
 
 import com.together.server.application.auth.AuthService;
+import com.together.server.application.auth.KakaoService;
 import com.together.server.application.auth.request.LoginRequest;
 import com.together.server.application.auth.request.RegisterRequest;
+import com.together.server.application.auth.response.KakaoUserResponse;
 import com.together.server.application.auth.response.TokenResponse;
+import com.together.server.application.member.response.MemberInfoResponse;
+import com.together.server.infra.oauth.KakaoOAuthClient;
 import com.together.server.infra.web.TokenCookieHandler;
 import com.together.server.support.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -24,21 +26,35 @@ public class AuthController {
     private final AuthService authService;
     private final TokenCookieHandler tokenCookieHandler;
 
+    private final KakaoOAuthClient kakaoOAuthClient;
+    private final KakaoService kakaoService;
+
     @PostMapping("/login")
     @Operation(summary = "로그인", description = "사용자 로그인 처리 API")
     public ResponseEntity<ApiResponse<Void>> login(@RequestBody LoginRequest request) {
         TokenResponse response = authService.login(request);
-        ResponseCookie accessTokenCookie = tokenCookieHandler.createAccessTokenCookie(response.token());
+        ResponseCookie accessTokenCookie = tokenCookieHandler.createAccessTokenCookie(response.accessToken());
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE, accessTokenCookie.toString())
                 .body(ApiResponse.success());
     }
 
+    @GetMapping("/login/kakao")
+    @Operation(summary = "카카오 로그인", description = "사용자 카카오 로그인으로 JWT 토큰 발급")
+    public ResponseEntity<ApiResponse<TokenResponse>> kakaoLogin(@RequestParam String code, HttpServletResponse response) {
+        String kakaoAccessToken = kakaoOAuthClient.getAccessToken(code);
+        KakaoUserResponse kakaoUser = kakaoService.getKakaoUser(kakaoAccessToken);
+        TokenResponse tokenResponse = authService.kakaoLogin(kakaoUser);
+
+        return ResponseEntity.ok(ApiResponse.success(tokenResponse));
+    }
+
+
     @PostMapping("/register")
     @Operation(summary = "회원가입", description = "사용자 회원가입 처리 API")
-    public ResponseEntity<ApiResponse<Void>> register(@RequestBody RegisterRequest request) {
-        authService.register(request);
-        return ResponseEntity.ok(ApiResponse.success());
+    public ResponseEntity<ApiResponse<MemberInfoResponse>> register(@RequestBody RegisterRequest request) {
+        MemberInfoResponse response = authService.register(request);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     @PostMapping("/logout")

--- a/src/main/java/com/together/server/application/auth/AuthService.java
+++ b/src/main/java/com/together/server/application/auth/AuthService.java
@@ -28,12 +28,12 @@ public class AuthService {
                 .findById(id)
                 .orElseThrow(() -> new MemberNotFoundException("존재하지 않는 사용자입니다. 사용자 식별자: %s".formatted(id)));
 
-        return new MemberDetailsResponse(member.getId(), member.getUsername(), member.getCreatedAt());
+        return new MemberDetailsResponse(member.getId(), member.getEmail(), member.getNickname(), member.getCreatedAt());
     }
 
     @Transactional(readOnly = true)
     public TokenResponse login(LoginRequest request) {
-        Member member = getByUsername(request.username());
+        Member member = getByEmail(request.email());
 
         if (!passwordEncoder.matches(request.password(), member.getPassword())) {
             throw new CoreException(ErrorType.MEMBER_PASSWORD_MISMATCH);
@@ -45,20 +45,20 @@ public class AuthService {
 
     @Transactional
     public String register(RegisterRequest request) {
-        if (memberRepository.existsByUsername(request.username())) {
+        if (memberRepository.existsByEmail(request.email())) {
             throw new CoreException(ErrorType.MEMBER_USERNAME_ALREADY_EXISTS);
         }
 
         String encodedPassword = passwordEncoder.encode(request.password());
-        Member member = new Member(request.username(), encodedPassword);
+        Member member = new Member(request.email(), request.nickname(), encodedPassword);
         Member savedMember = memberRepository.save(member);
 
         return savedMember.getId();
     }
 
-    private Member getByUsername(String username) {
+    private Member getByEmail(String email) {
         return memberRepository
-                .findByUsername(username)
+                .findByEmail(email)
                 .orElseThrow(() -> new CoreException(ErrorType.MEMBER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/together/server/application/auth/KakaoService.java
+++ b/src/main/java/com/together/server/application/auth/KakaoService.java
@@ -1,0 +1,31 @@
+package com.together.server.application.auth;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.together.server.application.auth.response.KakaoUserResponse;
+import com.together.server.infra.oauth.KakaoOAuthClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoService {
+    private final KakaoOAuthClient kakaoOAuthClient;
+    private final ObjectMapper objectMapper;
+
+    public KakaoUserResponse getKakaoUser(String accessToken) {
+        ResponseEntity<String> response = kakaoOAuthClient.getUserInfo(accessToken);
+
+        try {
+            JsonNode node = objectMapper.readTree(response.getBody());
+            String id = node.get("id").asText();
+            String email = node.path("kakao_account").path("email").asText();
+            String nickname = node.path("properties").path("nickname").asText();
+
+            return new KakaoUserResponse(id, email, nickname);
+        } catch (Exception e) {
+            throw new RuntimeException("카카오 사용자 정보를 파싱하는 중 오류가 발생했습니다.");
+        }
+    }
+}

--- a/src/main/java/com/together/server/application/auth/request/LoginRequest.java
+++ b/src/main/java/com/together/server/application/auth/request/LoginRequest.java
@@ -1,7 +1,7 @@
 package com.together.server.application.auth.request;
 
 public record LoginRequest(
-        String username,
+        String email,
         String password
 ) {
 }

--- a/src/main/java/com/together/server/application/auth/request/RegisterRequest.java
+++ b/src/main/java/com/together/server/application/auth/request/RegisterRequest.java
@@ -1,7 +1,8 @@
 package com.together.server.application.auth.request;
 
 public record RegisterRequest(
-        String username,
+        String email,
+        String nickname,
         String password
 ) {
 }

--- a/src/main/java/com/together/server/application/auth/response/KakaoUserResponse.java
+++ b/src/main/java/com/together/server/application/auth/response/KakaoUserResponse.java
@@ -1,0 +1,8 @@
+package com.together.server.application.auth.response;
+
+import java.time.Instant;
+
+public record KakaoUserResponse (
+        String kakaoId, String email, String nickname
+){
+}

--- a/src/main/java/com/together/server/application/auth/response/MemberDetailsResponse.java
+++ b/src/main/java/com/together/server/application/auth/response/MemberDetailsResponse.java
@@ -4,7 +4,8 @@ import java.time.Instant;
 
 public record MemberDetailsResponse(
         String id,
-        String username,
+        String email,
+        String nickname,
         Instant createdAt
 ) {
 }

--- a/src/main/java/com/together/server/application/auth/response/MemberDetailsResponse.java
+++ b/src/main/java/com/together/server/application/auth/response/MemberDetailsResponse.java
@@ -3,7 +3,7 @@ package com.together.server.application.auth.response;
 import java.time.Instant;
 
 public record MemberDetailsResponse(
-        String id,
+        Long id,
         String email,
         String nickname,
         Instant createdAt

--- a/src/main/java/com/together/server/application/auth/response/TokenResponse.java
+++ b/src/main/java/com/together/server/application/auth/response/TokenResponse.java
@@ -1,4 +1,3 @@
 package com.together.server.application.auth.response;
 
-public record TokenResponse(String token) {
-}
+public record TokenResponse(String accessToken) {}

--- a/src/main/java/com/together/server/application/member/MemberService.java
+++ b/src/main/java/com/together/server/application/member/MemberService.java
@@ -22,7 +22,8 @@ public class MemberService {
 
         return new MemberInfoResponse(
                 member.getId(),
-                member.getUsername(),
+                member.getEmail(),
+                member.getNickname(),
                 member.getCreatedAt()
         );
     }

--- a/src/main/java/com/together/server/application/member/response/MemberInfoResponse.java
+++ b/src/main/java/com/together/server/application/member/response/MemberInfoResponse.java
@@ -3,7 +3,7 @@ package com.together.server.application.member.response;
 import java.time.Instant;
 
 public record MemberInfoResponse(
-        String id,
+        Long id,
         String email,
         String nickname,
         Instant createdAt

--- a/src/main/java/com/together/server/application/member/response/MemberInfoResponse.java
+++ b/src/main/java/com/together/server/application/member/response/MemberInfoResponse.java
@@ -4,7 +4,8 @@ import java.time.Instant;
 
 public record MemberInfoResponse(
         String id,
-        String username,
+        String email,
+        String nickname,
         Instant createdAt
 ) {
 }

--- a/src/main/java/com/together/server/domain/member/Member.java
+++ b/src/main/java/com/together/server/domain/member/Member.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 
+
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -22,9 +23,9 @@ public class Member extends BaseEntity {
     @Column(name = "member_nickname", nullable = false)
     private String nickname;
 
-    public Member(String email, String password, String nickname) {
+    public Member(String email, String nickname, String password) {
         this.email = email;
-        this.password = password;
         this.nickname = nickname;
+        this.password = password;
     }
 }

--- a/src/main/java/com/together/server/domain/member/Member.java
+++ b/src/main/java/com/together/server/domain/member/Member.java
@@ -13,14 +13,18 @@ import lombok.NoArgsConstructor;
 @Getter
 public class Member extends BaseEntity {
 
-    @Column(nullable = false, unique = true)
-    private String username;
+    @Column(name = "member_email", nullable = false, unique = true)
+    private String email;
 
-    @Column(nullable = false)
+    @Column(name = "member_password", nullable = false)
     private String password;
 
-    public Member(String username, String password) {
-        this.username = username;
+    @Column(name = "member_nickname", nullable = false)
+    private String nickname;
+
+    public Member(String email, String password, String nickname) {
+        this.email = email;
         this.password = password;
+        this.nickname = nickname;
     }
 }

--- a/src/main/java/com/together/server/domain/member/MemberRepository.java
+++ b/src/main/java/com/together/server/domain/member/MemberRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, String> {
 
-    Optional<Member> findByUsername(String username);
+    Optional<Member> findByEmail(String email);
 
-    boolean existsByUsername(String username);
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/com/together/server/domain/member/MemberRepository.java
+++ b/src/main/java/com/together/server/domain/member/MemberRepository.java
@@ -8,4 +8,5 @@ public interface MemberRepository extends JpaRepository<Member, String> {
     Optional<Member> findByEmail(String email);
 
     boolean existsByEmail(String email);
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/together/server/infra/oauth/KakaoOAuthClient.java
+++ b/src/main/java/com/together/server/infra/oauth/KakaoOAuthClient.java
@@ -1,0 +1,73 @@
+package com.together.server.infra.oauth;
+
+import com.together.server.support.error.CoreException;
+import com.together.server.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoOAuthClient {
+
+    private static final String TOKEN_URL = "https://kauth.kakao.com/oauth/token";
+    private static final String USER_INFO_URL = "https://kapi.kakao.com/v2/user/me";
+    private static final String GRANT_TYPE = "authorization_code";
+
+    private final RestTemplate restTemplate;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
+    private String clientId;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.redirect-uri}")
+    private String redirectUri;
+
+    public String getAccessToken(String code) {
+        HttpHeaders headers = buildFormUrlEncodedHeaders();
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", GRANT_TYPE);
+        params.add("client_id", clientId);
+        params.add("redirect_uri", redirectUri);
+        params.add("code", code);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+
+        try {
+            ResponseEntity<Map> response = restTemplate.postForEntity(TOKEN_URL, request, Map.class);
+            if (response.getStatusCode().is2xxSuccessful() && response.getBody() != null) {
+                return (String) response.getBody().get("access_token");
+            } else {
+                throw new CoreException(ErrorType.KAKAO_TOKEN_REQUEST_FAILED);
+            }
+        } catch (Exception e) {
+            throw new CoreException(ErrorType.KAKAO_TOKEN_REQUEST_FAILED, e.getMessage());
+        }
+    }
+
+    public ResponseEntity<String> getUserInfo(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+        headers.set("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        HttpEntity<Void> entity = new HttpEntity<>(headers);
+
+        try {
+            return restTemplate.exchange(USER_INFO_URL, HttpMethod.GET, entity, String.class);
+        } catch (Exception e) {
+            throw new CoreException(ErrorType.KAKAO_USERINFO_REQUEST_FAILED, e.getMessage());
+        }
+    }
+
+    private HttpHeaders buildFormUrlEncodedHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        return headers;
+    }
+}

--- a/src/main/java/com/together/server/infra/persistence/BaseEntity.java
+++ b/src/main/java/com/together/server/infra/persistence/BaseEntity.java
@@ -1,8 +1,10 @@
 package com.together.server.infra.persistence;
 
 import io.hypersistence.utils.hibernate.id.Tsid;
-import jakarta.persistence.*;
-
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
 import java.time.Instant;
 import java.util.Objects;
 import lombok.Getter;
@@ -16,9 +18,9 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 public abstract class BaseEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Tsid
     @Column(nullable = false)
-    private String id;
+    private Long id;
 
     @CreatedDate
     @Column(nullable = false, updatable = false)
@@ -27,6 +29,7 @@ public abstract class BaseEntity {
     @LastModifiedDate
     @Column(nullable = false)
     private Instant updatedAt;
+
 
     @Override
     public boolean equals(Object o) {

--- a/src/main/java/com/together/server/infra/persistence/BaseEntity.java
+++ b/src/main/java/com/together/server/infra/persistence/BaseEntity.java
@@ -1,10 +1,8 @@
 package com.together.server.infra.persistence;
 
 import io.hypersistence.utils.hibernate.id.Tsid;
-import jakarta.persistence.Column;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.Id;
-import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.*;
+
 import java.time.Instant;
 import java.util.Objects;
 import lombok.Getter;
@@ -18,7 +16,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 public abstract class BaseEntity {
 
     @Id
-    @Tsid
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(nullable = false)
     private String id;
 

--- a/src/main/java/com/together/server/infra/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/together/server/infra/security/JwtAuthenticationFilter.java
@@ -52,7 +52,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String memberId = extractMemberId(token);
         MemberDetailsResponse memberInfo = fetchMemberInfo(memberId);
 
-        Authentication authentication = JwtAuthentication.of(memberInfo.id());
+        Authentication authentication = JwtAuthentication.of(String.valueOf(memberInfo.id()));
         SecurityContextHolder.getContext().setAuthentication(authentication);
     }
 

--- a/src/main/java/com/together/server/infra/security/SecurityConfig.java
+++ b/src/main/java/com/together/server/infra/security/SecurityConfig.java
@@ -14,6 +14,7 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.client.RestTemplate;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -56,7 +57,8 @@ public class SecurityConfig {
                                 "/swagger-ui.html",
                                 "/swagger-ui/index.html",
                                 "/swagger-resources/**",
-                                "/webjars/**"
+                                "/webjars/**",
+                                "/api/auth/login/kakao/**"
                         ).permitAll()
                         .anyRequest().authenticated())
                 .exceptionHandling(it -> it
@@ -78,5 +80,10 @@ public class SecurityConfig {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
         return source;
+    }
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
     }
 }

--- a/src/main/java/com/together/server/support/error/ErrorType.java
+++ b/src/main/java/com/together/server/support/error/ErrorType.java
@@ -12,10 +12,15 @@ public enum ErrorType {
     FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다.", LogLevel.WARN),
 
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다.", LogLevel.WARN),
-    MEMBER_USERNAME_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 존재하는 사용자 이름입니다.", LogLevel.WARN),
+    MEMBER_USEREMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다.", LogLevel.WARN),
+    MEMBER_USERNAME_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다.", LogLevel.WARN),
     MEMBER_PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다.", LogLevel.WARN),
-    ;
+    KAKAO_USERINFO_INCOMPLETE(HttpStatus.BAD_REQUEST, "카카오 로그인 중 에러가 발생했습니다.", LogLevel.WARN),
+    KAKAO_TOKEN_REQUEST_FAILED(HttpStatus.BAD_REQUEST, "카카오 토큰 요청 중 오류가 발생했습니다.", LogLevel.WARN),
+    KAKAO_USERINFO_REQUEST_FAILED(HttpStatus.BAD_REQUEST, "카카오 사용자 정보 요청 중 오류가 발생했습니다.", LogLevel.WARN);
 
+
+    public static final ErrorType SOCIAL_LOGIN_ONLY = null;
     private final HttpStatus status;
     private final String message;
     private final LogLevel logLevel;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,47 @@
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3307/middle_project2?useSSL=false&useUnicode=true&characterEncoding=UTF-8&serverTimezone=Asia/Seoul
+    username: together
+    password: middleproject2
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      driver-class-name: com.mysql.cj.jdbc.Driver
+      jdbc-url: jdbc:mysql://localhost:3307/middle_project2
+      username: together
+      password: middleproject2
+      pool-name: hikari-pool
+      maximum-pool-size: 1
+      minimum-idle: 1
+      connection-timeout: 5000
+      connection-init-sql: SELECT 1
+      idle-timeout: 600000
+      max-lifetime: 1800000
+      auto-commit: true
+
+  jpa:
+    open-in-view: false
+    show-sql: true
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        format_sql: true
+        highlight_sql: true
+
+security:
+  user:
+    name: together
+    password: together
+
+  jwt:
+    secret-key: security-1234567890-!@#$%^&*()-security-1234567890
+    expirationTime: 86400000 # 1 day
+  cookie:
+    token:
+      key: access_token
+      http-only: true
+      secure: true
+      domain: localhost
+      path: /
+      max-age: 86400 # 1 day
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,6 +17,17 @@ spring:
       idle-timeout: 600000
       max-lifetime: 1800000
       auto-commit: true
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id: 604b523d970a77490059b67f01f2e05c
+            redirect-uri: http://localhost:8080/api/auth/login/kakao
+            authorization-grant-type: authorization_code
+            scope:
+              - profile_nickname
+              - account_email
 
   jpa:
     open-in-view: false
@@ -32,6 +43,7 @@ security:
   user:
     name: together
     password: together
+
 
   jwt:
     secret-key: security-1234567890-!@#$%^&*()-security-1234567890


### PR DESCRIPTION
🚀 작업 내용
[ ] 로컬 로그인 구현 (JWT 활용) -> member_email, member_password, member_nickname으로 회원가입 되게 수정
[ ] 데이터베이스 member 테이블에 member_email, member_password, member_nickname, delflag, validation 추가
[ ] 데이터베이스 PK id -> TSID 방식으로 long 타입으로 저장되게 수정
[ ] 카카오 로그인 구현

🔍 리뷰 요청 사항
추후 refresh 토큰 발급 로직 추가할 예정입니다.

📝 연관 이슈
#1 