### PR TITLE
Feature/#16 SSE 기반 실시간 채팅 및 OpenAI 연동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ configurations {
 }
 
 repositories {
+
     mavenCentral()
 }
 
@@ -29,6 +30,7 @@ ext {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux' // WebClient
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 

--- a/src/main/java/com/together/server/api/auth/AuthController.java
+++ b/src/main/java/com/together/server/api/auth/AuthController.java
@@ -55,7 +55,8 @@ public class AuthController {
         Accessor accessor = (Accessor) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         String memberId = accessor.id();
         authService.updateFirstLoginInfo(memberId, request);
-        return ResponseEntity.ok(ApiResponse.success());
+        return ResponseEntity.ok(ApiResponse.success(null));
+
     }
 
     @GetMapping("/login/kakao")

--- a/src/main/java/com/together/server/api/chat/ChatController.java
+++ b/src/main/java/com/together/server/api/chat/ChatController.java
@@ -1,0 +1,75 @@
+package com.together.server.api.chat;
+
+import com.together.server.application.chat.SseChatService;
+import com.together.server.application.chat.request.ChatRequest;
+import com.together.server.infra.security.Accessor;
+import jakarta.validation.Valid;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+/**
+ * 채팅 관련 API를 제공하는 컨트롤러 클래스입니다.
+ *
+ * 채팅방 연결, 메시지 전송, 요약 요청 기능을 포함합니다.
+ */
+@RestController
+@RequestMapping("/api/chat")
+public class ChatController {
+
+    private final SseChatService sseChatService;
+
+    /**
+     * 생성자 - SseChatService 주입
+     *
+     * @param sseChatService SSE 기반 채팅 서비스
+     */
+    public ChatController(SseChatService sseChatService) {
+        this.sseChatService = sseChatService;
+    }
+
+    /**
+     * 클라이언트와 SSE 연결을 생성하여 채팅방에 연결합니다.
+     *
+     * @param accessor 인증된 사용자 정보
+     * @param roomId 채팅방 식별자
+     * @return SseEmitter 객체 (서버-센트 이벤트 연결)
+     */
+    @GetMapping("/connect/{roomId}")
+    public SseEmitter connect(
+            @AuthenticationPrincipal Accessor accessor,
+            @PathVariable String roomId
+    ) {
+        return sseChatService.connect(accessor.id(), roomId);
+    }
+
+    /**
+     * 채팅방에 메시지를 전송합니다.
+     *
+     * @param accessor 인증된 사용자 정보
+     * @param roomId 채팅방 식별자
+     * @param req 메시지 요청 데이터 (content 포함)
+     */
+    @PostMapping("/message/{roomId}")
+    public void sendMessage(
+            @AuthenticationPrincipal Accessor accessor,
+            @PathVariable String roomId,
+            @RequestBody @Valid ChatRequest req
+    ) {
+        sseChatService.sendMessage(accessor.id(), roomId, "user", req.content());
+    }
+
+    /**
+     * 채팅방 메시지 요약을 요청합니다.
+     *
+     * @param accessor 인증된 사용자 정보
+     * @param roomId 채팅방 식별자
+     */
+    @PostMapping("/summary/{roomId}")
+    public void requestSummary(
+            @AuthenticationPrincipal Accessor accessor,
+            @PathVariable String roomId
+    ) {
+        sseChatService.requestSummary(accessor.id(), roomId);
+    }
+}

--- a/src/main/java/com/together/server/application/chat/SseChatService.java
+++ b/src/main/java/com/together/server/application/chat/SseChatService.java
@@ -1,0 +1,147 @@
+package com.together.server.application.chat;
+
+import com.together.server.application.sse.SseEmitterService;
+import com.together.server.domain.chat.ChatMessage;
+import com.together.server.domain.chat.ChatSession;
+import com.together.server.infra.openai.OpenAiChatClient;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import reactor.core.Disposable;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+/**
+ * 서비스 간 서버 전송(EventStream) 기반의 실시간 채팅 기능을 제공하는 서비스입니다.
+ * 사용자별 채팅 세션을 관리하며, OpenAI API를 통한 스미싱 분석 및 요약 요청 기능도 포함합니다.
+ */
+@Service
+public class SseChatService {
+
+    /** 사용자별로 방(room) 별 채팅 세션을 저장하는 맵 */
+    private final Map<String, Map<String, ChatSession>> chatSessions = new ConcurrentHashMap<>();
+
+    /** SSE 이벤트 전송을 처리하는 서비스 */
+    private final SseEmitterService sseEmitterService;
+
+    /** OpenAI GPT API 클라이언트 */
+    private final OpenAiChatClient openAiChatClient;
+
+    /**
+     * 생성자
+     *
+     * @param sseEmitterService SSE 전송을 위한 서비스
+     * @param openAiChatClient OpenAI GPT 호출을 위한 클라이언트
+     */
+    public SseChatService(
+            SseEmitterService sseEmitterService,
+            OpenAiChatClient openAiChatClient
+    ) {
+        this.sseEmitterService = sseEmitterService;
+        this.openAiChatClient = openAiChatClient;
+    }
+
+    /**
+     * 사용자가 채팅방에 연결할 때 SSE 연결을 생성하고 ChatSession을 등록합니다.
+     *
+     * @param userId 사용자 ID
+     * @param roomId 채팅방 ID
+     * @return 생성된 SseEmitter
+     */
+    public SseEmitter connect(String userId, String roomId) {
+        chatSessions.computeIfAbsent(userId, k -> new ConcurrentHashMap<>());
+        SseEmitter emitter = sseEmitterService.createEmitter(userId + "_" + roomId);
+        ChatSession session = new ChatSession(userId, roomId, emitter);
+        chatSessions.get(userId).put(roomId, session);
+        return emitter;
+    }
+
+    /**
+     * 사용자의 메시지를 채팅 세션에 저장하고, OpenAI GPT를 통해 스미싱 분석 결과를 SSE로 스트리밍 전송합니다.
+     *
+     * @param userId 사용자 ID
+     * @param roomId 채팅방 ID
+     * @param sender 메시지 발신자 (예: 사용자 또는 시스템)
+     * @param content 메시지 내용
+     */
+    public void sendMessage(String userId, String roomId, String sender, String content) {
+        ChatSession session = getSession(userId, roomId);
+        if (session == null) return;
+
+        session.addMessage(new ChatMessage(sender, content));
+        sendEvent(session, "question", content);
+
+        String promptForMessage =
+                "당신은 스미싱 탐지 전문가 AI입니다. 사용자가 보낸 문자메시지가 스미싱인지 아닌지를 분석하여 아래 형식으로 답변해주세요.\n"
+                        + "\n"
+                        + "- 스미싱 가능성: 높음 / 보통 / 낮음 (세 단계 중 하나만 선택)\n"
+                        + "- 판단 근거: 왜 그렇게 판단했는지 명확히 설명 (URL 포함 여부, 개인정보 요구 여부, 긴급성 유도 등)\n"
+                        + "- 사용자 주의사항: 사용자가 어떻게 대응해야 하는지 간단히 안내 (예: 링크 클릭 금지, 삭제 권장 등)\n"
+                        + "\n"
+                        + "아래는 사용자가 보낸 문자메시지입니다:\n"
+                        + "\n"
+                        + "\"\"\"\n"
+                        + content
+                        + "\n\"\"\"\n"
+                        + "\n"
+                        + "이제 분석 결과를 위 형식에 맞추어 출력하세요.";
+
+        Disposable subscription = openAiChatClient.streamChatCompletion(promptForMessage)
+                .subscribe(
+                        chunk -> sendEvent(session, "stream_chat", chunk),
+                        error -> sseEmitterService.removeEmitter(userId + "_" + roomId),
+                        () -> sendEvent(session, "done", "done")
+                );
+
+        // 추후 취소 기능을 구현하려면 subscription을 저장해두고 관리 필요
+    }
+
+    /**
+     * 현재 채팅 세션의 대화 내용을 요약 요청하여 응답을 SSE로 전송합니다.
+     *
+     * @param userId 사용자 ID
+     * @param roomId 채팅방 ID
+     */
+    public void requestSummary(String userId, String roomId) {
+        ChatSession session = getSession(userId, roomId);
+        if (session == null) return;
+
+        String chatHistory = session.getMessages().stream()
+                .map(msg -> msg.getSender() + ": " + msg.getContent())
+                .collect(Collectors.joining("\n"));
+
+        String promptForSummary = "아래 대화 기록을 한 단어로 요약해주세요:\n" + chatHistory;
+
+        String summary = openAiChatClient.getChatCompletion(promptForSummary);
+        sendEvent(session, "summary", summary);
+    }
+
+    /**
+     * 특정 사용자-방의 채팅 세션을 조회합니다.
+     *
+     * @param userId 사용자 ID
+     * @param roomId 채팅방 ID
+     * @return ChatSession 객체 (없으면 null)
+     */
+    private ChatSession getSession(String userId, String roomId) {
+        Map<String, ChatSession> userSessions = chatSessions.get(userId);
+        if (userSessions == null) return null;
+        return userSessions.get(roomId);
+    }
+
+    /**
+     * SSE 이벤트를 전송합니다. 전송 실패 시 emitter를 제거합니다.
+     *
+     * @param session 대상 채팅 세션
+     * @param eventType 이벤트 타입
+     * @param data 전송할 데이터
+     */
+    private void sendEvent(ChatSession session, String eventType, String data) {
+        try {
+            sseEmitterService.sendEvent(session.getUserId() + "_" + session.getRoomId(), eventType, data);
+        } catch (Exception e) {
+            sseEmitterService.removeEmitter(session.getUserId() + "_" + session.getRoomId());
+        }
+    }
+}

--- a/src/main/java/com/together/server/application/chat/request/ChatRequest.java
+++ b/src/main/java/com/together/server/application/chat/request/ChatRequest.java
@@ -1,0 +1,9 @@
+package com.together.server.application.chat.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ChatRequest(
+        @NotBlank(message = "content는 빈 값일 수 없습니다.")
+        String content
+) {
+}

--- a/src/main/java/com/together/server/application/sse/SseEmitterData.java
+++ b/src/main/java/com/together/server/application/sse/SseEmitterData.java
@@ -1,0 +1,54 @@
+package com.together.server.application.sse;
+
+import java.time.Instant;
+import lombok.Getter;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+/**
+ * SseEmitterData는 SseEmitter와 관련된 메타데이터를 관리하는 클래스입니다.
+ * <p>
+ * 이 클래스는 SseEmitter 인스턴스, 생성 시각, 마지막 이벤트 전송 시각을 포함합니다.
+ * {@link #updateLastEventTime()} 메서드를 통해 마지막 이벤트 시각을 갱신할 수 있습니다.
+ */
+@Getter
+public class SseEmitterData {
+
+    private final SseEmitter emitter;
+    private final Instant createdAt;
+    private Instant lastEventTime;
+
+    /**
+     * 생성자 - 모든 필드를 초기화합니다.
+     *
+     * @param emitter       SSE 통신을 위한 SseEmitter 인스턴스
+     * @param createdAt     SseEmitter 생성 시각
+     * @param lastEventTime 마지막 이벤트 전송 시각
+     */
+    public SseEmitterData(
+            SseEmitter emitter,
+            Instant createdAt,
+            Instant lastEventTime
+    ) {
+        this.emitter = emitter;
+        this.createdAt = createdAt;
+        this.lastEventTime = lastEventTime;
+    }
+
+    /**
+     * 정적 팩토리 메서드로 현재 시각을 기준으로 SseEmitterData 인스턴스를 생성합니다.
+     *
+     * @param emitter SSE 통신을 위한 SseEmitter 인스턴스
+     * @return 새로운 SseEmitterData 객체
+     */
+    public static SseEmitterData of(SseEmitter emitter) {
+        Instant now = Instant.now();
+        return new SseEmitterData(emitter, now, now);
+    }
+
+    /**
+     * 마지막 이벤트 전송 시각을 현재 시각으로 갱신합니다.
+     */
+    public void updateLastEventTime() {
+        this.lastEventTime = Instant.now();
+    }
+}

--- a/src/main/java/com/together/server/application/sse/SseEmitterService.java
+++ b/src/main/java/com/together/server/application/sse/SseEmitterService.java
@@ -1,0 +1,114 @@
+package com.together.server.application.sse;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * SSE 연결을 관리하는 서비스 클래스입니다.
+ * <p>
+ * 클라이언트별로 SseEmitter를 생성, 저장, 이벤트 전송, 제거 기능을 제공합니다.
+ * 연결 유지 시간은 1일로 설정되어 있습니다.
+ */
+@Component
+public class SseEmitterService {
+
+    private static final long EMITTER_TIMEOUT = TimeUnit.DAYS.toMillis(1);
+
+    private final Map<String, SseEmitterData> emitters = new ConcurrentHashMap<>();
+
+    /**
+     * 클라이언트 ID를 기반으로 SseEmitter를 생성합니다.
+     * 기존에 해당 클라이언트 ID로 등록된 emitter가 있다면 제거 후 새로 생성합니다.
+     * <p>
+     * 생성된 emitter에 연결 완료 이벤트("connected")를 즉시 전송합니다.
+     *
+     * @param clientId 클라이언트 식별자
+     * @return 새로 생성된 SseEmitter 인스턴스
+     */
+    public SseEmitter createEmitter(String clientId) {
+        if (emitters.containsKey(clientId)) {
+            removeEmitter(clientId);
+        }
+
+        SseEmitter emitter = new SseEmitter(EMITTER_TIMEOUT);
+
+        SseEmitterData emitterData = SseEmitterData.of(emitter);
+
+        emitter.onCompletion(() -> removeEmitter(clientId));
+        emitter.onTimeout(() -> removeEmitter(clientId));
+        emitter.onError(throwable -> removeEmitter(clientId));
+
+        emitters.put(clientId, emitterData);
+
+        try {
+            emitter.send(SseEmitter.event().name("connected").data("connected"));
+        } catch (Exception e) {
+            // 로그 처리 필요: 연결 이벤트 전송 실패
+        }
+
+        return emitter;
+    }
+
+    /**
+     * 특정 클라이언트 ID에 이벤트를 전송합니다.
+     * 해당 클라이언트의 emitter가 존재하지 않으면 아무 동작도 하지 않습니다.
+     * 전송 실패 시 emitter를 제거합니다.
+     *
+     * @param clientId  클라이언트 식별자
+     * @param eventType 전송할 이벤트 이름
+     * @param data      전송할 데이터 객체
+     */
+    public void sendEvent(
+            String clientId,
+            String eventType,
+            Object data
+    ) {
+        if (!emitters.containsKey(clientId)) {
+            return;
+        }
+
+        SseEmitterData emitterData = emitters.get(clientId);
+
+        try {
+            emitterData.getEmitter()
+                    .send(
+                            SseEmitter.event()
+                                    .name(eventType)
+                                    .data(data)
+                    );
+
+            emitterData.updateLastEventTime();
+
+        } catch (Exception e) {
+            // 로그 처리 필요: 이벤트 전송 실패
+            removeEmitter(clientId);
+        }
+    }
+
+    /**
+     * 클라이언트 ID에 해당하는 SseEmitter를 종료하고, 내부 저장소에서 제거합니다.
+     * emitter 종료 과정에서 예외 발생해도 무시하고 제거를 진행합니다.
+     *
+     * @param clientId 클라이언트 식별자
+     */
+    public void removeEmitter(String clientId) {
+        try {
+            if (!emitters.containsKey(clientId)) {
+                return;
+            }
+
+            SseEmitterData emitterData = emitters.get(clientId);
+            emitterData.getEmitter().complete();
+
+        } catch (Exception e) {
+            // 로그 처리 필요: emitter 종료 실패
+        } finally {
+            emitters.remove(clientId);
+        }
+    }
+}
+

--- a/src/main/java/com/together/server/domain/chat/ChatMessage.java
+++ b/src/main/java/com/together/server/domain/chat/ChatMessage.java
@@ -1,0 +1,11 @@
+package com.together.server.domain.chat;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ChatMessage {
+    private final String sender;
+    private final String content;
+}

--- a/src/main/java/com/together/server/domain/chat/ChatSession.java
+++ b/src/main/java/com/together/server/domain/chat/ChatSession.java
@@ -1,0 +1,26 @@
+package com.together.server.domain.chat;
+
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import java.util.Queue;
+import java.util.LinkedList;
+import lombok.Getter;
+
+@Getter
+public class ChatSession {
+    private final String userId;
+    private final String roomId;
+    private final SseEmitter emitter;
+    private final Queue<ChatMessage> messages;
+
+    public ChatSession(String userId, String roomId, SseEmitter emitter) {
+        this.userId = userId;
+        this.roomId = roomId;
+        this.emitter = emitter;
+        this.messages = new LinkedList<>();
+    }
+
+
+    public void addMessage(ChatMessage message) {
+        messages.add(message);
+    }
+}

--- a/src/main/java/com/together/server/infra/openai/OpenAiChatClient.java
+++ b/src/main/java/com/together/server/infra/openai/OpenAiChatClient.java
@@ -1,0 +1,107 @@
+package com.together.server.infra.openai;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * OpenAI GPT 모델과의 통신을 담당하는 클라이언트 컴포넌트입니다.
+ * - 대화형 프롬프트 요청 및 스트리밍 응답 처리
+ * - 단일 응답 처리
+ */
+@Component
+public class OpenAiChatClient {
+
+    private final WebClient openaiWebClient;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    /**
+     * 생성자 - OpenAI와 통신할 WebClient를 주입받습니다.
+     *
+     * @param openaiWebClient "openaiWebClient"로 지정된 WebClient Bean
+     */
+    public OpenAiChatClient(@Qualifier("openaiWebClient") WebClient openaiWebClient) {
+        this.openaiWebClient = openaiWebClient;
+    }
+
+    /**
+     * OpenAI GPT 모델에 메시지를 보내고 스트리밍 방식으로 응답을 수신합니다.
+     *
+     * @param prompt 사용자 입력 프롬프트
+     * @return Flux<String> 형태의 GPT 응답 스트림
+     */
+    public Flux<String> streamChatCompletion(String prompt) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("model", "gpt-3.5-turbo");
+        body.put("messages", List.of(Map.of("role", "user", "content", prompt)));
+        body.put("stream", true);
+
+        return openaiWebClient.post()
+                .bodyValue(body)
+                .retrieve()
+                .bodyToFlux(String.class)
+                .map(this::extractStreamText)
+                .filter(chunk -> chunk != null && !chunk.isEmpty());
+    }
+
+    /**
+     * OpenAI 스트리밍 응답에서 텍스트 부분만 추출합니다.
+     *
+     * @param json JSON 형식의 응답 문자열
+     * @return 추출된 텍스트 조각, 없으면 빈 문자열
+     */
+    private String extractStreamText(String json) {
+        try {
+            if (json == null || json.isEmpty() || json.contains("[DONE]")) {
+                return "";
+            }
+            JsonNode root = objectMapper.readTree(json);
+            JsonNode contentNode = root.path("choices").get(0).path("delta").path("content");
+            return contentNode.isMissingNode() ? "" : contentNode.asText();
+        } catch (Exception e) {
+            return "";
+        }
+    }
+
+    /**
+     * OpenAI GPT 모델에 메시지를 보내고 단일 응답을 받습니다.
+     *
+     * @param prompt 사용자 입력 프롬프트
+     * @return 단일 응답 문자열 (전체 메시지)
+     */
+    public String getChatCompletion(String prompt) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("model", "gpt-3.5-turbo");
+        body.put("messages", List.of(Map.of("role", "user", "content", prompt)));
+
+        return openaiWebClient.post()
+                .bodyValue(body)
+                .retrieve()
+                .bodyToMono(String.class)
+                .map(this::extractFullText)
+                .block();  // 동기 블로킹 방식
+    }
+
+    /**
+     * OpenAI 응답 JSON에서 전체 메시지를 추출합니다.
+     *
+     * @param json JSON 형식의 응답 문자열
+     * @return 추출된 응답 텍스트, 실패 시 에러 메시지
+     */
+    private String extractFullText(String json) {
+        try {
+            JsonNode root = objectMapper.readTree(json);
+            JsonNode contentNode = root.path("choices").get(0).path("message").path("content");
+            return contentNode.isMissingNode() ? "AI 응답 파싱 오류" : contentNode.asText();
+        } catch (Exception e) {
+            return "AI 응답 파싱 오류: " + e.getMessage();
+        }
+    }
+}

--- a/src/main/java/com/together/server/infra/webclient/WebClientConfig.java
+++ b/src/main/java/com/together/server/infra/webclient/WebClientConfig.java
@@ -1,0 +1,22 @@
+package com.together.server.infra.webclient;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Value("${openai.api.key}")
+    private String openaiApiKey;
+
+    @Bean(name = "openaiWebClient")
+    public WebClient openaiWebClient() {
+        return WebClient.builder()
+                .baseUrl("https://api.openai.com/v1/chat/completions")
+                .defaultHeader("Authorization", "Bearer " + openaiApiKey)
+                .defaultHeader("Content-Type", "application/json")
+                .build();
+    }
+}

--- a/src/main/java/com/together/server/support/error/ErrorType.java
+++ b/src/main/java/com/together/server/support/error/ErrorType.java
@@ -33,7 +33,7 @@ public enum ErrorType {
     INVALID_PHONE_NUMBER_FORMAT(40105,HttpStatus.BAD_REQUEST, "전화번호 형식이 올바르지 않습니다.", LogLevel.WARN),
     REQUIRED_MEMBER_ID(40103,HttpStatus.BAD_REQUEST, "전화번호는 필수 항목입니다.", LogLevel.WARN),
     REQUIRED_NICKNAME(40102, HttpStatus.BAD_REQUEST, "닉네임은 필수 항목입니다.", LogLevel.WARN),
-    REQUIRED_PASSWORD(40104, HttpStatus.BAD_REQUEST, "비밀번호는 필수 항목입니다.", LogLevel.WARN);
+    REQUIRED_PASSWORD(40104, HttpStatus.BAD_REQUEST, "비밀번호는 필수 항목입니다.", LogLevel.WARN),
     
     ALREADY_UPDATED_FIRST_INFO(40124, HttpStatus.BAD_REQUEST, "이미 추가 항목이 설정된 사용자입니다.", LogLevel.WARN),
     REQUIRED_AGE_GROUP(40121, HttpStatus.BAD_REQUEST, "연령대는 필수 항목입니다.", LogLevel.WARN),


### PR DESCRIPTION
### 🚀 작업 내용

<!-- 주요 변경 사항이나 강조하고 싶은 내용을 설명해주세요. -->

- [x] 채팅방 SSE 연결 API 및 서비스 구조 추가
- [x] 채팅방 연결(SSE Emitter 생성) 및 사용자별 채팅 세션 관리
- [x] 메시지 전송 시 OpenAI GPT로 요청 및 결과를 SSE로 실시간 스트리밍
- [x] OpenAI API 연동 및 WebClient 기반 외부 통신 설정

### 🔍 리뷰 요청 사항

![image](https://github.com/user-attachments/assets/728ba298-dcca-4956-9618-1562276ade46)
- sse 연결 확인

![image](https://github.com/user-attachments/assets/30ed9394-be14-48c3-a105-c070a958049d)
- 메시지 전송 POST 요청 확인

## application.yml 파일에 openai key가 추가었으니 해당 파일로 수정 부탁드립니다.
## 외부 API 호출을 위한 비동기 HTTP 클라이언트로 WebClient를 도입하였고, 이에 따른 의존성을 추가하였습니다.

### 📝 연관 이슈

<!-- 연관된 이슈를 아래와 같이 명시해 닫아주세요.>

> ex) close #16 

