### PR TITLE
[FEAT] #14 template API 구현

### DIFF
--- a/src/main/java/com/together/server/api/template/TemplateController.java
+++ b/src/main/java/com/together/server/api/template/TemplateController.java
@@ -26,14 +26,27 @@ public class TemplateController {
 
     @PostMapping
     @Operation(summary = "템플릿 저장", description = "추천 요금제 정보를 템플릿으로 저장")
-    public ResponseEntity<ApiResponse<Void>> saveTemplate(@RequestBody TemplateSaveRequest request) {
-        templateService.saveTemplate(request);
+    public ResponseEntity<ApiResponse<Void>> saveTemplate(@RequestBody TemplateSaveRequest request,
+    @AuthenticationPrincipal Accessor accessor) {
+
+        if (accessor.isGuest()) {
+            throw new CoreException(ErrorType.FORBIDDEN);
+        }
+
+        Long memberId = Long.valueOf(accessor.id());
+        templateService.saveTemplate(request, memberId);
         return ResponseEntity.ok(ApiResponse.success(null));
     }
 
-    @GetMapping("/{memberId}")
+    @GetMapping
     @Operation(summary = "템플릿 목록 조회", description = "사용자의 템플릿 목록 조회")
-    public ResponseEntity<ApiResponse<List<TemplateSimpleResponse>>> listTemplates(@PathVariable Long memberId) {
+    public ResponseEntity<ApiResponse<List<TemplateSimpleResponse>>> listTemplates(@AuthenticationPrincipal Accessor accessor) {
+
+        if (accessor.isGuest()) {
+            throw new CoreException(ErrorType.FORBIDDEN);
+        }
+
+        Long memberId = Long.valueOf(accessor.id());
         List<TemplateSimpleResponse> response = templateService.getTemplates(memberId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
@@ -61,7 +74,6 @@ public class TemplateController {
 
         Long memberId = Long.valueOf(accessor.id());
         templateService.deleteTemplate(templateId, memberId);
-
         return ResponseEntity.ok(ApiResponse.success(null));
     }
 }

--- a/src/main/java/com/together/server/api/template/TemplateController.java
+++ b/src/main/java/com/together/server/api/template/TemplateController.java
@@ -38,23 +38,29 @@ public class TemplateController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    @GetMapping("/detail/{id}")
+    @GetMapping("/detail/{templateId}")
     @Operation(summary = "템플릿 상세 조회", description = "템플릿 ID로 해당 템플릿 상세 정보 조회")
-    public ResponseEntity<ApiResponse<TemplateDetailResponse>> detailTemplate(@PathVariable Long id) {
-        TemplateDetailResponse response = templateService.getTemplateDetail(id);
-        return ResponseEntity.ok(ApiResponse.success(response));
-    }
-
-    @DeleteMapping("/{id}")
-    @Operation(summary = "템플릿 삭제", description = "템플릿 ID로 해당 템플릿 삭제")
-    public ResponseEntity<ApiResponse<Void>> deleteTemplate(@PathVariable Long id, @AuthenticationPrincipal Accessor accessor) {
+    public ResponseEntity<ApiResponse<TemplateDetailResponse>> detailTemplate(@PathVariable Long templateId, @AuthenticationPrincipal Accessor accessor) {
 
         if (accessor.isGuest()) {
             throw new CoreException(ErrorType.FORBIDDEN);
         }
 
         Long memberId = Long.valueOf(accessor.id());
-        templateService.deleteTemplate(id, memberId);
+        TemplateDetailResponse response = templateService.getTemplateDetail(templateId, memberId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @DeleteMapping("/{templateId}")
+    @Operation(summary = "템플릿 삭제", description = "템플릿 ID로 해당 템플릿 삭제")
+    public ResponseEntity<ApiResponse<Void>> deleteTemplate(@PathVariable Long templateId, @AuthenticationPrincipal Accessor accessor) {
+
+        if (accessor.isGuest()) {
+            throw new CoreException(ErrorType.FORBIDDEN);
+        }
+
+        Long memberId = Long.valueOf(accessor.id());
+        templateService.deleteTemplate(templateId, memberId);
 
         return ResponseEntity.ok(ApiResponse.success(null));
     }

--- a/src/main/java/com/together/server/api/template/TemplateController.java
+++ b/src/main/java/com/together/server/api/template/TemplateController.java
@@ -5,10 +5,14 @@ import com.together.server.application.template.TemplateService;
 import com.together.server.application.template.request.TemplateSaveRequest;
 import com.together.server.application.template.response.TemplateDetailResponse;
 import com.together.server.application.template.response.TemplateSimpleResponse;
+import com.together.server.infra.security.Accessor;
+import com.together.server.support.error.CoreException;
+import com.together.server.support.error.ErrorType;
 import com.together.server.support.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -43,8 +47,15 @@ public class TemplateController {
 
     @DeleteMapping("/{id}")
     @Operation(summary = "템플릿 삭제", description = "템플릿 ID로 해당 템플릿 삭제")
-    public ResponseEntity<ApiResponse<Void>> deleteTemplate(@PathVariable Long id) {
-        templateService.deleteTemplate(id);
+    public ResponseEntity<ApiResponse<Void>> deleteTemplate(@PathVariable Long id, @AuthenticationPrincipal Accessor accessor) {
+
+        if (accessor.isGuest()) {
+            throw new CoreException(ErrorType.FORBIDDEN);
+        }
+
+        Long memberId = Long.valueOf(accessor.id());
+        templateService.deleteTemplate(id, memberId);
+
         return ResponseEntity.ok(ApiResponse.success(null));
     }
 }

--- a/src/main/java/com/together/server/api/template/TemplateController.java
+++ b/src/main/java/com/together/server/api/template/TemplateController.java
@@ -1,0 +1,50 @@
+package com.together.server.api.template;
+
+
+import com.together.server.application.template.TemplateService;
+import com.together.server.application.template.request.TemplateSaveRequest;
+import com.together.server.application.template.response.TemplateDetailResponse;
+import com.together.server.application.template.response.TemplateSimpleResponse;
+import com.together.server.support.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/templates")
+public class TemplateController {
+
+    private final TemplateService templateService;
+
+    @PostMapping
+    @Operation(summary = "템플릿 저장", description = "추천 요금제 정보를 템플릿으로 저장")
+    public ResponseEntity<ApiResponse<Void>> saveTemplate(@RequestBody TemplateSaveRequest request) {
+        templateService.saveTemplate(request);
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
+    @GetMapping("/{memberId}")
+    @Operation(summary = "템플릿 목록 조회", description = "사용자의 템플릿 목록 조회")
+    public ResponseEntity<ApiResponse<List<TemplateSimpleResponse>>> listTemplates(@PathVariable Long memberId) {
+        List<TemplateSimpleResponse> response = templateService.getTemplates(memberId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping("/detail/{id}")
+    @Operation(summary = "템플릿 상세 조회", description = "템플릿 ID로 해당 템플릿 상세 정보 조회")
+    public ResponseEntity<ApiResponse<TemplateDetailResponse>> detailTemplate(@PathVariable Long id) {
+        TemplateDetailResponse response = templateService.getTemplateDetail(id);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @DeleteMapping("/{id}")
+    @Operation(summary = "템플릿 삭제", description = "템플릿 ID로 해당 템플릿 삭제")
+    public ResponseEntity<ApiResponse<Void>> deleteTemplate(@PathVariable Long id) {
+        templateService.deleteTemplate(id);
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+}

--- a/src/main/java/com/together/server/application/template/TemplateService.java
+++ b/src/main/java/com/together/server/application/template/TemplateService.java
@@ -21,9 +21,9 @@ public class TemplateService {
     private final TemplateRepository templateRepository;
 
     @Transactional
-    public void saveTemplate(TemplateSaveRequest request) {
+    public void saveTemplate(TemplateSaveRequest request, Long memberId) {
         Template template = new Template(
-                request.memberId(),
+                memberId,
                 request.chatId(),
                 request.title(),
                 request.content(),
@@ -62,5 +62,4 @@ public class TemplateService {
 
         templateRepository.delete(t);
     }
-
 }

--- a/src/main/java/com/together/server/application/template/TemplateService.java
+++ b/src/main/java/com/together/server/application/template/TemplateService.java
@@ -40,22 +40,27 @@ public class TemplateService {
     }
 
     @Transactional(readOnly = true)
-    public TemplateDetailResponse getTemplateDetail(Long id) {
-        Template t = templateRepository.findById(id)
+    public TemplateDetailResponse getTemplateDetail(Long templateId, Long memberId) {
+        Template t = templateRepository.findById(templateId)
                 .orElseThrow(() -> new CoreException(ErrorType.TEMPLATE_NOT_FOUND));
+
+        if (!t.getMemberId().equals(memberId)) {
+            throw new CoreException(ErrorType.FORBIDDEN);
+        }
+
         return new TemplateDetailResponse(t.getId(), t.getTitle(), t.getContent(), t.getChatId(), t.getPlanId());
     }
 
     @Transactional
     public void deleteTemplate(Long templateId, Long memberId) {
-        Template template = templateRepository.findById(templateId)
+        Template t = templateRepository.findById(templateId)
                 .orElseThrow(() -> new CoreException(ErrorType.TEMPLATE_NOT_FOUND));
 
-        if (!template.getMemberId().equals(memberId)) {
+        if (!t.getMemberId().equals(memberId)) {
             throw new CoreException(ErrorType.FORBIDDEN);
         }
 
-        templateRepository.delete(template);
+        templateRepository.delete(t);
     }
 
 }

--- a/src/main/java/com/together/server/application/template/TemplateService.java
+++ b/src/main/java/com/together/server/application/template/TemplateService.java
@@ -47,9 +47,14 @@ public class TemplateService {
     }
 
     @Transactional
-    public void deleteTemplate(Long id) {
-        Template template = templateRepository.findById(id)
+    public void deleteTemplate(Long templateId, Long memberId) {
+        Template template = templateRepository.findById(templateId)
                 .orElseThrow(() -> new CoreException(ErrorType.TEMPLATE_NOT_FOUND));
+
+        if (!template.getMemberId().equals(memberId)) {
+            throw new CoreException(ErrorType.FORBIDDEN);
+        }
+
         templateRepository.delete(template);
     }
 

--- a/src/main/java/com/together/server/application/template/TemplateService.java
+++ b/src/main/java/com/together/server/application/template/TemplateService.java
@@ -1,0 +1,56 @@
+package com.together.server.application.template;
+
+import com.together.server.application.template.request.TemplateSaveRequest;
+import com.together.server.application.template.response.TemplateDetailResponse;
+import com.together.server.application.template.response.TemplateSimpleResponse;
+import com.together.server.domain.template.Template;
+import com.together.server.domain.template.TemplateRepository;
+import com.together.server.support.error.CoreException;
+import com.together.server.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class TemplateService {
+
+    private final TemplateRepository templateRepository;
+
+    @Transactional
+    public void saveTemplate(TemplateSaveRequest request) {
+        Template template = new Template(
+                request.memberId(),
+                request.chatId(),
+                request.title(),
+                request.content(),
+                request.planId()
+        );
+        templateRepository.save(template);
+    }
+
+    @Transactional(readOnly = true)
+    public List<TemplateSimpleResponse> getTemplates(Long memberId) {
+        return templateRepository.findAllByMemberId(memberId).stream()
+                .map(t -> new TemplateSimpleResponse(t.getId(), t.getTitle()))
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public TemplateDetailResponse getTemplateDetail(Long id) {
+        Template t = templateRepository.findById(id)
+                .orElseThrow(() -> new CoreException(ErrorType.TEMPLATE_NOT_FOUND));
+        return new TemplateDetailResponse(t.getId(), t.getTitle(), t.getContent(), t.getChatId(), t.getPlanId());
+    }
+
+    @Transactional
+    public void deleteTemplate(Long id) {
+        Template template = templateRepository.findById(id)
+                .orElseThrow(() -> new CoreException(ErrorType.TEMPLATE_NOT_FOUND));
+        templateRepository.delete(template);
+    }
+
+}

--- a/src/main/java/com/together/server/application/template/request/TemplateSaveRequest.java
+++ b/src/main/java/com/together/server/application/template/request/TemplateSaveRequest.java
@@ -1,4 +1,4 @@
 package com.together.server.application.template.request;
 
-public record TemplateSaveRequest(Long memberId, Integer chatId, String title, String content, Integer planId) {
+public record TemplateSaveRequest(Integer chatId, String title, String content, Integer planId) {
 }

--- a/src/main/java/com/together/server/application/template/request/TemplateSaveRequest.java
+++ b/src/main/java/com/together/server/application/template/request/TemplateSaveRequest.java
@@ -1,0 +1,4 @@
+package com.together.server.application.template.request;
+
+public record TemplateSaveRequest(Long memberId, Integer chatId, String title, String content, Integer planId) {
+}

--- a/src/main/java/com/together/server/application/template/response/TemplateDetailResponse.java
+++ b/src/main/java/com/together/server/application/template/response/TemplateDetailResponse.java
@@ -1,0 +1,4 @@
+package com.together.server.application.template.response;
+
+public record TemplateDetailResponse(Long id, String title, String content, Integer chatId, Integer planId) {
+}

--- a/src/main/java/com/together/server/application/template/response/TemplateSimpleResponse.java
+++ b/src/main/java/com/together/server/application/template/response/TemplateSimpleResponse.java
@@ -1,0 +1,4 @@
+package com.together.server.application.template.response;
+
+public record TemplateSimpleResponse(Long id, String title) {
+}

--- a/src/main/java/com/together/server/domain/template/Template.java
+++ b/src/main/java/com/together/server/domain/template/Template.java
@@ -1,0 +1,37 @@
+package com.together.server.domain.template;
+
+import com.together.server.infra.persistence.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Template extends BaseEntity {
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Column(name = "chat_id", nullable = false)
+    private Integer chatId;
+
+    @Column(name = "title", nullable = false, length = 100)
+    private String title;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name = "plan_id", nullable = false)
+    private Integer planId;
+
+    public Template(Long memberId, Integer chatId, String title, String content, Integer planId) {
+        this.memberId = memberId;
+        this.chatId = chatId;
+        this.title = title;
+        this.content = content;
+        this.planId = planId;
+    }
+}

--- a/src/main/java/com/together/server/domain/template/TemplateRepository.java
+++ b/src/main/java/com/together/server/domain/template/TemplateRepository.java
@@ -1,0 +1,8 @@
+package com.together.server.domain.template;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface TemplateRepository extends JpaRepository<Template, Long> {
+    List<Template> findAllByMemberId(Long memberId);
+}

--- a/src/main/java/com/together/server/infra/swagger/SwaggerConfig.java
+++ b/src/main/java/com/together/server/infra/swagger/SwaggerConfig.java
@@ -44,4 +44,12 @@ public class SwaggerConfig {
                 .pathsToMatch("/api/members/**")
                 .build();
     }
+
+    @Bean
+    public GroupedOpenApi templateApi() {
+        return GroupedOpenApi.builder()
+                .group("template")
+                .pathsToMatch("/api/templates/**")
+                .build();
+    }
 }

--- a/src/main/java/com/together/server/support/error/ErrorType.java
+++ b/src/main/java/com/together/server/support/error/ErrorType.java
@@ -10,7 +10,7 @@ public enum ErrorType {
     // 공통
     INTERNAL_SERVER_ERROR(50000, HttpStatus.INTERNAL_SERVER_ERROR, "서버 내 예상치 못한 오류가 발생했습니다.", LogLevel.ERROR),
     UNAUTHORIZED(40001, HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다.", LogLevel.WARN),
-    FORBIDDEN(40002, HttpStatus.FORBIDDEN, "접근 권한이 없습니다.", LogLevel.WARN),
+    FORBIDDEN(40003, HttpStatus.FORBIDDEN, "접근 권한이 없습니다.", LogLevel.WARN),
 
     // 회원
     MEMBER_NOT_FOUND(40114, HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다.", LogLevel.WARN),

--- a/src/main/java/com/together/server/support/error/ErrorType.java
+++ b/src/main/java/com/together/server/support/error/ErrorType.java
@@ -40,7 +40,11 @@ public enum ErrorType {
     REQUIRED_PREFERRED_PRICE(40122, HttpStatus.BAD_REQUEST, "선호 요금제는 필수 항목입니다.", LogLevel.WARN),
     REQUIRED_FONT_MODE(40123, HttpStatus.BAD_REQUEST, "글씨 크기 선택은 필수 항목입니다.", LogLevel.WARN);
 
-  
+
+    // 템플릿
+    TEMPLATE_NOT_FOUND(40301, HttpStatus.NOT_FOUND, "저장된 템플릿이 없습니다.", LogLevel.WARN);
+
+
     public static final ErrorType SOCIAL_LOGIN_ONLY = null;
     private final int code;
     private final HttpStatus status;

--- a/src/main/java/com/together/server/support/error/ErrorType.java
+++ b/src/main/java/com/together/server/support/error/ErrorType.java
@@ -38,8 +38,7 @@ public enum ErrorType {
     ALREADY_UPDATED_FIRST_INFO(40124, HttpStatus.BAD_REQUEST, "이미 추가 항목이 설정된 사용자입니다.", LogLevel.WARN),
     REQUIRED_AGE_GROUP(40121, HttpStatus.BAD_REQUEST, "연령대는 필수 항목입니다.", LogLevel.WARN),
     REQUIRED_PREFERRED_PRICE(40122, HttpStatus.BAD_REQUEST, "선호 요금제는 필수 항목입니다.", LogLevel.WARN),
-    REQUIRED_FONT_MODE(40123, HttpStatus.BAD_REQUEST, "글씨 크기 선택은 필수 항목입니다.", LogLevel.WARN);
-
+    REQUIRED_FONT_MODE(40123, HttpStatus.BAD_REQUEST, "글씨 크기 선택은 필수 항목입니다.", LogLevel.WARN),
 
     // 템플릿
     TEMPLATE_NOT_FOUND(40301, HttpStatus.NOT_FOUND, "저장된 템플릿이 없습니다.", LogLevel.WARN);


### PR DESCRIPTION
### 🚀 작업 내용
- [x] template 저장/전체조회/상세조회/삭제 API 구현
- [x] Swagger 명세 추가 (`@Operation` 적용, `SwaggerConfig`에 추가)
- [x] 에러 처리 적용


### 🔍 리뷰 요청 사항
- 전체적인 API 응답 구조 및 Swagger 확인
- 조회할 때 어떤 정보 받아올지는 임의로 지정 -> 추후 논의

### 📝 연관 이슈
> close #14 