### PR TITLE
[FEAT] #15 회원 정보 수정, 회원 탈퇴 로직 구현

### DIFF
--- a/src/main/java/com/together/server/api/auth/AuthController.java
+++ b/src/main/java/com/together/server/api/auth/AuthController.java
@@ -55,7 +55,7 @@ public class AuthController {
         Accessor accessor = (Accessor) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         String memberId = accessor.id();
         authService.updateFirstLoginInfo(memberId, request);
-        return ResponseEntity.ok(ApiResponse.success());
+        return ResponseEntity.ok(ApiResponse.success(null));
     }
 
     @GetMapping("/login/kakao")

--- a/src/main/java/com/together/server/api/member/MemberController.java
+++ b/src/main/java/com/together/server/api/member/MemberController.java
@@ -47,7 +47,7 @@ public class MemberController {
         MemberInfoResponse response = memberService.getMemberInfo(accessor.id());
         memberService.deleteMember(memberId);
 
-        return ResponseEntity.ok(ApiResponse.success(response));
+        return ResponseEntity.ok(ApiResponse.success(null));
     }
 }
 

--- a/src/main/java/com/together/server/api/member/MemberController.java
+++ b/src/main/java/com/together/server/api/member/MemberController.java
@@ -27,7 +27,7 @@ public class MemberController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    @PatchMapping("/infoUpdate")
+    @PatchMapping("/me")
     @Operation(summary = "회원 정보 수정", description = "사용자 닉네임, 요금제, 글씨 크기 수정")
     public ResponseEntity<ApiResponse<UpdateMemberInfoResponse>> updateMemberInfo(
             @RequestBody UpdateMemberInfoRequest request
@@ -39,7 +39,7 @@ public class MemberController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    @DeleteMapping("/delete")
+    @DeleteMapping("/me")
     @Operation(summary = "회원 탈퇴", description = "사용자 탈퇴")
     public ResponseEntity<ApiResponse<MemberInfoResponse>> deleteMember() {
         Accessor accessor = (Accessor) SecurityContextHolder.getContext().getAuthentication().getPrincipal();

--- a/src/main/java/com/together/server/api/member/MemberController.java
+++ b/src/main/java/com/together/server/api/member/MemberController.java
@@ -1,15 +1,17 @@
 package com.together.server.api.member;
 
 import com.together.server.application.member.MemberService;
+import com.together.server.application.member.request.UpdateMemberInfoRequest;
 import com.together.server.application.member.response.MemberInfoResponse;
+import com.together.server.application.member.response.UpdateMemberInfoResponse;
 import com.together.server.infra.security.Accessor;
 import com.together.server.support.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,6 +23,29 @@ public class MemberController {
     @GetMapping("/me")
     public ResponseEntity<ApiResponse<MemberInfoResponse>> getMyInfo(@AuthenticationPrincipal Accessor accessor) {
         MemberInfoResponse response = memberService.getMemberInfo(accessor.id());
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @PatchMapping("/infoUpdate")
+    @Operation(summary = "회원 정보 수정", description = "사용자 닉네임, 요금제, 글씨 크기 수정")
+    public ResponseEntity<ApiResponse<UpdateMemberInfoResponse>> updateMemberInfo(
+            @RequestBody UpdateMemberInfoRequest request
+    ) {
+        Accessor accessor = (Accessor) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        String memberId = accessor.id();
+        UpdateMemberInfoResponse response = memberService.updateMemberInfo(memberId, request);
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @DeleteMapping("/delete")
+    @Operation(summary = "회원 탈퇴", description = "사용자 탈퇴")
+    public ResponseEntity<ApiResponse<MemberInfoResponse>> deleteMember() {
+        Accessor accessor = (Accessor) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        String memberId = accessor.id();
+        MemberInfoResponse response = memberService.getMemberInfo(accessor.id());
+        memberService.deleteMember(memberId);
 
         return ResponseEntity.ok(ApiResponse.success(response));
     }

--- a/src/main/java/com/together/server/application/member/MemberService.java
+++ b/src/main/java/com/together/server/application/member/MemberService.java
@@ -1,6 +1,8 @@
 package com.together.server.application.member;
 
+import com.together.server.application.member.request.UpdateMemberInfoRequest;
 import com.together.server.application.member.response.MemberInfoResponse;
+import com.together.server.application.member.response.UpdateMemberInfoResponse;
 import com.together.server.domain.member.Member;
 import com.together.server.domain.member.MemberRepository;
 import com.together.server.support.error.CoreException;
@@ -26,5 +28,43 @@ public class MemberService {
                 member.getNickname(),
                 member.getCreatedAt()
         );
+    }
+
+    @Transactional
+    public UpdateMemberInfoResponse updateMemberInfo(String memberId, UpdateMemberInfoRequest request) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CoreException(ErrorType.MEMBER_NOT_FOUND));
+
+        if (request.nickname() != null) {
+            member.updateNickname(request.nickname());
+        }
+
+        if (request.preferredPrice() != null) {
+            member.updatePreferredPrice(request.preferredPrice());
+        }
+
+        if (request.fontMode() != null) {
+            member.updateFontMode(request.fontMode());
+        }
+
+        return new UpdateMemberInfoResponse(
+                member.getMemberId(),
+                member.getNickname(),
+                member.getPreferredPrice(),
+                member.getFontMode(),
+                member.getUpdatedAt()
+        );
+    }
+
+    @Transactional
+    public void deleteMember(String memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CoreException(ErrorType.MEMBER_NOT_FOUND));
+
+        if (member.isDeleted()) {
+            throw new CoreException(ErrorType.MEMBER_WITHDRAWN);
+        }
+
+        member.delete();
     }
 }

--- a/src/main/java/com/together/server/application/member/request/UpdateMemberInfoRequest.java
+++ b/src/main/java/com/together/server/application/member/request/UpdateMemberInfoRequest.java
@@ -1,0 +1,8 @@
+package com.together.server.application.member.request;
+
+public record UpdateMemberInfoRequest(
+        String nickname,
+        String preferredPrice,
+        String fontMode
+) {
+}

--- a/src/main/java/com/together/server/application/member/response/UpdateMemberInfoResponse.java
+++ b/src/main/java/com/together/server/application/member/response/UpdateMemberInfoResponse.java
@@ -1,0 +1,12 @@
+package com.together.server.application.member.response;
+
+import java.time.Instant;
+
+public record UpdateMemberInfoResponse(
+        String memberId,
+        String nickname,
+        String preferredPrice,
+        String fontMode,
+        Instant updated_at
+) {
+}

--- a/src/main/java/com/together/server/domain/member/Member.java
+++ b/src/main/java/com/together/server/domain/member/Member.java
@@ -35,11 +35,15 @@ public class Member extends BaseEntity {
     @Column(name = "is_first_login", nullable = false)
     private Boolean isFirstLogin = true;
 
+    @Column(name = "delflag", nullable = false)
+    private Boolean delflag = false;
+
     public Member(String memberId, String nickname, String password) {
         this.memberId = memberId;
         this.nickname = nickname;
         this.password = password;
         this.isFirstLogin = true;
+        this.delflag = false;
     }
 
     public void updateFirstLoginInfo(String ageGroup, String preferredPrice, Boolean fontMode) {
@@ -48,4 +52,25 @@ public class Member extends BaseEntity {
         this.fontMode = String.valueOf(fontMode);
         this.isFirstLogin = false;
     }
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void updatePreferredPrice(String preferredPrice) {
+        this.preferredPrice = preferredPrice;
+    }
+
+    public void updateFontMode(String fontMode) {
+        this.fontMode = fontMode;
+    }
+
+    public boolean isDeleted() {
+        return delflag;
+    }
+
+    public void delete() {
+        this.delflag = true;
+    }
+
 }

--- a/src/main/java/com/together/server/domain/member/MemberRepository.java
+++ b/src/main/java/com/together/server/domain/member/MemberRepository.java
@@ -8,5 +8,4 @@ public interface MemberRepository extends JpaRepository<Member, String> {
     Optional<Member> findByMemberId(String memberId);
 
     boolean existsByMemberId(String memberId);
-    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/together/server/support/error/ErrorType.java
+++ b/src/main/java/com/together/server/support/error/ErrorType.java
@@ -33,12 +33,13 @@ public enum ErrorType {
     INVALID_PHONE_NUMBER_FORMAT(40105,HttpStatus.BAD_REQUEST, "전화번호 형식이 올바르지 않습니다.", LogLevel.WARN),
     REQUIRED_MEMBER_ID(40103,HttpStatus.BAD_REQUEST, "전화번호는 필수 항목입니다.", LogLevel.WARN),
     REQUIRED_NICKNAME(40102, HttpStatus.BAD_REQUEST, "닉네임은 필수 항목입니다.", LogLevel.WARN),
-    REQUIRED_PASSWORD(40104, HttpStatus.BAD_REQUEST, "비밀번호는 필수 항목입니다.", LogLevel.WARN);
+    REQUIRED_PASSWORD(40104, HttpStatus.BAD_REQUEST, "비밀번호는 필수 항목입니다.", LogLevel.WARN),
     
     ALREADY_UPDATED_FIRST_INFO(40124, HttpStatus.BAD_REQUEST, "이미 추가 항목이 설정된 사용자입니다.", LogLevel.WARN),
     REQUIRED_AGE_GROUP(40121, HttpStatus.BAD_REQUEST, "연령대는 필수 항목입니다.", LogLevel.WARN),
     REQUIRED_PREFERRED_PRICE(40122, HttpStatus.BAD_REQUEST, "선호 요금제는 필수 항목입니다.", LogLevel.WARN),
-    REQUIRED_FONT_MODE(40123, HttpStatus.BAD_REQUEST, "글씨 크기 선택은 필수 항목입니다.", LogLevel.WARN);
+    REQUIRED_FONT_MODE(40123, HttpStatus.BAD_REQUEST, "글씨 크기 선택은 필수 항목입니다.", LogLevel.WARN),
+    MEMBER_WITHDRAWN(40125, HttpStatus.BAD_REQUEST, "이미 탈퇴한 사용자입니다.", LogLevel.WARN);
 
   
     public static final ErrorType SOCIAL_LOGIN_ONLY = null;


### PR DESCRIPTION
### 🚀 작업 내용

- [x] 회원 정보 수정 구현 (닉네임, 선호 요금제, 글씨 크기 모드)
- [x] 회원 탈퇴 로직 구현
- [x] 로그인 시 탈퇴한 사용자 여부 조회 (에러 타입 추가 ErrorType.MEMBER_WITHDRAWN)

### 🔍 리뷰 요청 사항

회원 정보를 수정한 경우

<img width="904" alt="image" src="https://github.com/user-attachments/assets/6f637c6b-b9cc-4776-b461-927d093aa9ae" />

이미 탈퇴한 사용자가 로그인을 시도할 경우

<img width="907" alt="image" src="https://github.com/user-attachments/assets/f40560ba-7fe0-45de-bc06-a76ee22544c0" />


### 📝 연관 이슈

> close #15 