### PR TITLE
[FEAT] #20 notification API 구현

### DIFF
--- a/src/main/java/com/together/server/api/notification/NotificationController.java
+++ b/src/main/java/com/together/server/api/notification/NotificationController.java
@@ -1,0 +1,42 @@
+package com.together.server.api.notification;
+
+import com.together.server.application.notification.NotificationService;
+import com.together.server.application.notification.request.NotificationCreateRequest;
+import com.together.server.application.notification.response.NotificationDetailResponse;
+import com.together.server.application.notification.response.NotificationSimpleResponse;
+import com.together.server.support.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notifications")
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @PostMapping
+    @Operation(summary = "알림장 작성", description = "알림장 작성(어드민 기능 구현 전까지 임시로 사용)")
+    public ResponseEntity<ApiResponse<Void>> createNotification(@RequestBody NotificationCreateRequest request) {
+        notificationService.createNotification(request);
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
+    @GetMapping
+    @Operation(summary = "알림장 목록 조회", description = "모든 알림장 목록을 조회")
+    public ResponseEntity<ApiResponse<List<NotificationSimpleResponse>>> getAllNotifications(){
+        return ResponseEntity.ok(ApiResponse.success(notificationService.getAllNotifications()));
+    }
+
+    @GetMapping("/{notificationId}")
+    @Operation(summary = "알림장 상세 조회", description = "알림장 ID를 통해 상세 내용 조회")
+    public ResponseEntity<ApiResponse<NotificationDetailResponse>> getNotificationDetail(@PathVariable Long notificationId){
+        return ResponseEntity.ok(ApiResponse.success(notificationService.getNotificationDetail(notificationId)));
+    }
+
+
+}

--- a/src/main/java/com/together/server/application/notification/NotificationService.java
+++ b/src/main/java/com/together/server/application/notification/NotificationService.java
@@ -5,6 +5,7 @@ import com.together.server.application.notification.response.NotificationDetailR
 import com.together.server.application.notification.response.NotificationSimpleResponse;
 import com.together.server.domain.notification.Notification;
 import com.together.server.domain.notification.NotificationRepository;
+import com.together.server.domain.notification.validator.NotificationCreateValidator;
 import com.together.server.support.error.CoreException;
 import com.together.server.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
@@ -19,9 +20,11 @@ import java.util.stream.Collectors;
 public class NotificationService {
 
     private final NotificationRepository notificationRepository;
+    private final NotificationCreateValidator notificationCreateValidator;
 
     @Transactional
     public void createNotification(NotificationCreateRequest request) {
+        notificationCreateValidator.validate(request);
         Notification notification = new Notification(request.title(), request.content());
         notificationRepository.save(notification);
     }

--- a/src/main/java/com/together/server/application/notification/NotificationService.java
+++ b/src/main/java/com/together/server/application/notification/NotificationService.java
@@ -1,0 +1,43 @@
+package com.together.server.application.notification;
+
+import com.together.server.application.notification.request.NotificationCreateRequest;
+import com.together.server.application.notification.response.NotificationDetailResponse;
+import com.together.server.application.notification.response.NotificationSimpleResponse;
+import com.together.server.domain.notification.Notification;
+import com.together.server.domain.notification.NotificationRepository;
+import com.together.server.support.error.CoreException;
+import com.together.server.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+
+    @Transactional
+    public void createNotification(NotificationCreateRequest request) {
+        Notification notification = new Notification(request.title(), request.content());
+        notificationRepository.save(notification);
+    }
+
+    @Transactional(readOnly = true)
+    public List<NotificationSimpleResponse> getAllNotifications() {
+        return notificationRepository.findAll().stream()
+                .map(n -> new NotificationSimpleResponse(n.getId(), n.getTitle(), n.getCreatedAt()))
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public NotificationDetailResponse getNotificationDetail(Long id) {
+        Notification n = notificationRepository.findById(id)
+                .orElseThrow(() -> new CoreException(ErrorType.NOTIFICATION_NOT_FOUND));
+
+        return new NotificationDetailResponse(n.getId(), n.getTitle(), n.getContent(), n.getCreatedAt());
+    }
+}

--- a/src/main/java/com/together/server/application/notification/request/NotificationCreateRequest.java
+++ b/src/main/java/com/together/server/application/notification/request/NotificationCreateRequest.java
@@ -1,0 +1,4 @@
+package com.together.server.application.notification.request;
+
+public record NotificationCreateRequest(String title, String content) {
+}

--- a/src/main/java/com/together/server/application/notification/response/NotificationDetailResponse.java
+++ b/src/main/java/com/together/server/application/notification/response/NotificationDetailResponse.java
@@ -1,0 +1,6 @@
+package com.together.server.application.notification.response;
+
+import java.time.Instant;
+
+public record NotificationDetailResponse(Long notificationId, String title, String content, Instant createdAt) {
+}

--- a/src/main/java/com/together/server/application/notification/response/NotificationSimpleResponse.java
+++ b/src/main/java/com/together/server/application/notification/response/NotificationSimpleResponse.java
@@ -1,0 +1,7 @@
+package com.together.server.application.notification.response;
+
+import java.time.Instant;
+
+public record NotificationSimpleResponse(Long notificationId, String title, Instant createdAt) {
+}
+

--- a/src/main/java/com/together/server/domain/notification/Notification.java
+++ b/src/main/java/com/together/server/domain/notification/Notification.java
@@ -1,0 +1,25 @@
+package com.together.server.domain.notification;
+
+import com.together.server.infra.persistence.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification extends BaseEntity {
+
+    @Column(name = "title", nullable = false, length = 100)
+    private String title;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    public Notification(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
+
+}

--- a/src/main/java/com/together/server/domain/notification/NotificationRepository.java
+++ b/src/main/java/com/together/server/domain/notification/NotificationRepository.java
@@ -1,0 +1,6 @@
+package com.together.server.domain.notification;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+}

--- a/src/main/java/com/together/server/domain/notification/validator/NotificationCreateValidator.java
+++ b/src/main/java/com/together/server/domain/notification/validator/NotificationCreateValidator.java
@@ -1,0 +1,20 @@
+package com.together.server.domain.notification.validator;
+
+import com.together.server.application.notification.request.NotificationCreateRequest;
+import com.together.server.support.error.CoreException;
+import com.together.server.support.error.ErrorType;
+import org.springframework.stereotype.Component;
+
+@Component
+public class NotificationCreateValidator {
+
+    public void validate(NotificationCreateRequest request) {
+        if (request.title() == null || request.title().trim().isEmpty()) {
+            throw new CoreException(ErrorType.INVALID_NOTIFICATION_TITLE);
+        }
+
+        if (request.content() == null || request.content().trim().isEmpty()) {
+            throw new CoreException(ErrorType.INVALID_NOTIFICATION_CONTENT);
+        }
+    }
+}

--- a/src/main/java/com/together/server/infra/persistence/BaseEntity.java
+++ b/src/main/java/com/together/server/infra/persistence/BaseEntity.java
@@ -27,7 +27,7 @@ public abstract class BaseEntity {
     private Instant createdAt;
 
     @LastModifiedDate
-    @Column(nullable = false)
+    @Column(nullable = true)
     private Instant updatedAt;
 
 

--- a/src/main/java/com/together/server/infra/swagger/SwaggerConfig.java
+++ b/src/main/java/com/together/server/infra/swagger/SwaggerConfig.java
@@ -52,4 +52,12 @@ public class SwaggerConfig {
                 .pathsToMatch("/api/templates/**")
                 .build();
     }
+
+    @Bean
+    public GroupedOpenApi notificationApi() {
+        return GroupedOpenApi.builder()
+                .group("notification")
+                .pathsToMatch("/api/notifications/**")
+                .build();
+    }
 }

--- a/src/main/java/com/together/server/support/error/ErrorType.java
+++ b/src/main/java/com/together/server/support/error/ErrorType.java
@@ -41,7 +41,11 @@ public enum ErrorType {
     REQUIRED_FONT_MODE(40123, HttpStatus.BAD_REQUEST, "글씨 크기 선택은 필수 항목입니다.", LogLevel.WARN),
 
     // 템플릿
-    TEMPLATE_NOT_FOUND(40301, HttpStatus.NOT_FOUND, "저장된 템플릿이 없습니다.", LogLevel.WARN);
+    TEMPLATE_NOT_FOUND(40301, HttpStatus.NOT_FOUND, "저장된 템플릿이 없습니다.", LogLevel.WARN),
+
+    // 알림장
+    NOTIFICATION_NOT_FOUND(40401, HttpStatus.NOT_FOUND, "해당 알림장이 없습니다.", LogLevel.WARN);
+
 
 
     public static final ErrorType SOCIAL_LOGIN_ONLY = null;

--- a/src/main/java/com/together/server/support/error/ErrorType.java
+++ b/src/main/java/com/together/server/support/error/ErrorType.java
@@ -44,7 +44,9 @@ public enum ErrorType {
     TEMPLATE_NOT_FOUND(40301, HttpStatus.NOT_FOUND, "저장된 템플릿이 없습니다.", LogLevel.WARN),
 
     // 알림장
-    NOTIFICATION_NOT_FOUND(40401, HttpStatus.NOT_FOUND, "해당 알림장이 없습니다.", LogLevel.WARN);
+    NOTIFICATION_NOT_FOUND(40401, HttpStatus.NOT_FOUND, "해당 알림장이 없습니다.", LogLevel.WARN),
+    INVALID_NOTIFICATION_TITLE(40402, HttpStatus.BAD_REQUEST, "알림장 제목은 비어 있을 수 없습니다.", LogLevel.WARN),
+    INVALID_NOTIFICATION_CONTENT(40403, HttpStatus.BAD_REQUEST, "알림장 내용은 비어 있을 수 없습니다.", LogLevel.WARN);
 
 
 


### PR DESCRIPTION
### 🚀 작업 내용
- [x] Notification API 구현
- [x] 알림장 생성 시 제목, 내용 유효성 검증 로직 추가
- [x] 에러처리 적용

### 🔍 리뷰 요청 사항
- 전체적인 API 응답 구조 및 Swagger 확인
- 알림장 작성은 admin만 할 수 있게 하기로 했는데 admin은 시간이 되면 구현하기로 했으므로 우선은 작성 API를 구현함
- `BaseEntity`의 `updated_at`컬럼에 계속 zero date가 들어가서 에러가 발생 -> `BaseEntity`의 `updated_at`의 `nullable`을 true로 변경

### 📝 연관 이슈
> close #20 