### PR TITLE
[FEAT] #23 faqchip API 구현

### DIFF
--- a/src/main/java/com/together/server/api/faq/FAQChipController.java
+++ b/src/main/java/com/together/server/api/faq/FAQChipController.java
@@ -1,0 +1,4 @@
+package com.together.server.api.faq;
+
+public class FAQChipController {
+}

--- a/src/main/java/com/together/server/api/faq/FAQChipController.java
+++ b/src/main/java/com/together/server/api/faq/FAQChipController.java
@@ -7,10 +7,7 @@ import com.together.server.support.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 

--- a/src/main/java/com/together/server/api/faq/FAQChipController.java
+++ b/src/main/java/com/together/server/api/faq/FAQChipController.java
@@ -1,4 +1,35 @@
 package com.together.server.api.faq;
 
+import com.together.server.application.faq.FAQChipService;
+import com.together.server.application.faq.response.FAQChipAnswerResponse;
+import com.together.server.application.faq.response.FAQChipResponse;
+import com.together.server.support.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/faq-chips")
 public class FAQChipController {
+
+    private final FAQChipService faqChipService;
+
+    @GetMapping
+    @Operation(summary = "FAQ 칩 목록 조회", description = "자주 묻는 질문 목록 조회")
+    public ResponseEntity<ApiResponse<List<FAQChipResponse>>> getChips() {
+        return ResponseEntity.ok(ApiResponse.success(faqChipService.getChips()));
+    }
+
+    @GetMapping("/{chipId}/answer")
+    @Operation(summary = "FAQ 답변 조회", description = "FAQ 칩 ID로 해당 질문의 답변 조회")
+    public ResponseEntity<ApiResponse<FAQChipAnswerResponse>> getChipAnswer(@PathVariable Long chipId) {
+        return ResponseEntity.ok(ApiResponse.success(faqChipService.getChipAnswer(chipId)));
+    }
 }

--- a/src/main/java/com/together/server/application/faq/FAQChipService.java
+++ b/src/main/java/com/together/server/application/faq/FAQChipService.java
@@ -22,7 +22,7 @@ public class FAQChipService {
     @Transactional(readOnly = true)
     public List<FAQChipResponse> getChips() {
         return faqChipRepository.findAll().stream()
-                .map(f -> new FAQChipResponse(f.getId(), f.getQuestion()))
+                .map(f -> new FAQChipResponse(f.getChipId(), f.getQuestion()))
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/together/server/application/faq/FAQChipService.java
+++ b/src/main/java/com/together/server/application/faq/FAQChipService.java
@@ -1,0 +1,36 @@
+package com.together.server.application.faq;
+
+import com.together.server.application.faq.response.FAQChipAnswerResponse;
+import com.together.server.application.faq.response.FAQChipResponse;
+import com.together.server.domain.faq.FAQChip;
+import com.together.server.domain.faq.FAQChipRepository;
+import com.together.server.support.error.CoreException;
+import com.together.server.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class FAQChipService {
+
+    private final FAQChipRepository faqChipRepository;
+
+    @Transactional(readOnly = true)
+    public List<FAQChipResponse> getChips() {
+        return faqChipRepository.findAll().stream()
+                .map(f -> new FAQChipResponse(f.getId(), f.getQuestion()))
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public FAQChipAnswerResponse getChipAnswer(Long chipId) {
+        FAQChip chip = faqChipRepository.findById(chipId)
+                .orElseThrow(() -> new CoreException(ErrorType.QUESTION_NOT_FOUND));
+
+        return new FAQChipAnswerResponse(chip.getAnswer());
+    }
+}

--- a/src/main/java/com/together/server/application/faq/response/FAQChipAnswerResponse.java
+++ b/src/main/java/com/together/server/application/faq/response/FAQChipAnswerResponse.java
@@ -1,0 +1,4 @@
+package com.together.server.application.faq.response;
+
+public record FAQChipAnswerResponse(String answer) {
+}

--- a/src/main/java/com/together/server/application/faq/response/FAQChipResponse.java
+++ b/src/main/java/com/together/server/application/faq/response/FAQChipResponse.java
@@ -1,0 +1,4 @@
+package com.together.server.application.faq.response;
+
+public record FAQChipResponse(Long id, String question) {
+}

--- a/src/main/java/com/together/server/domain/faq/FAQChip.java
+++ b/src/main/java/com/together/server/domain/faq/FAQChip.java
@@ -1,8 +1,6 @@
 package com.together.server.domain.faq;
 
-import com.together.server.infra.persistence.BaseEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,7 +8,13 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class FAQChip extends BaseEntity {
+@Table(name = "faq_chip")
+public class FAQChip {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "chip_id", nullable = false)
+    private Long chipId;
 
     @Column(name = "question", nullable = false, length = 255)
     private String question;

--- a/src/main/java/com/together/server/domain/faq/FAQChip.java
+++ b/src/main/java/com/together/server/domain/faq/FAQChip.java
@@ -1,0 +1,25 @@
+package com.together.server.domain.faq;
+
+import com.together.server.infra.persistence.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FAQChip extends BaseEntity {
+
+    @Column(name = "question", nullable = false, length = 255)
+    private String question;
+
+    @Column(name = "answer", nullable = false, length = 1000)
+    private String answer;
+
+    public FAQChip(String question, String answer) {
+        this.question = question;
+        this.answer = answer;
+    }
+}

--- a/src/main/java/com/together/server/domain/faq/FAQChipRepository.java
+++ b/src/main/java/com/together/server/domain/faq/FAQChipRepository.java
@@ -1,0 +1,6 @@
+package com.together.server.domain.faq;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FAQChipRepository extends JpaRepository<FAQChip, Long> {
+}

--- a/src/main/java/com/together/server/infra/swagger/SwaggerConfig.java
+++ b/src/main/java/com/together/server/infra/swagger/SwaggerConfig.java
@@ -52,4 +52,12 @@ public class SwaggerConfig {
                 .pathsToMatch("/api/templates/**")
                 .build();
     }
+
+    @Bean
+    public GroupedOpenApi faqChipApi() {
+        return GroupedOpenApi.builder()
+                .group("faq-chip")
+                .pathsToMatch("/api/faq-chips/**")
+                .build();
+    }
 }

--- a/src/main/java/com/together/server/support/error/ErrorType.java
+++ b/src/main/java/com/together/server/support/error/ErrorType.java
@@ -41,8 +41,10 @@ public enum ErrorType {
     REQUIRED_FONT_MODE(40123, HttpStatus.BAD_REQUEST, "글씨 크기 선택은 필수 항목입니다.", LogLevel.WARN),
 
     // 템플릿
-    TEMPLATE_NOT_FOUND(40301, HttpStatus.NOT_FOUND, "저장된 템플릿이 없습니다.", LogLevel.WARN);
+    TEMPLATE_NOT_FOUND(40301, HttpStatus.NOT_FOUND, "저장된 템플릿이 없습니다.", LogLevel.WARN),
 
+    // FAQ
+    QUESTION_NOT_FOUND(40401, HttpStatus.NOT_FOUND, "해당하는 질문이 없습니다.", LogLevel.WARN);
 
     public static final ErrorType SOCIAL_LOGIN_ONLY = null;
     private final int code;


### PR DESCRIPTION
### 🚀 작업 내용
- [x] FAQChip API 구현 
  - 질문 전체 조회 - 칩 버튼에 띄울 질문
  - 질문에 해당하는 답변 조회 - 칩 버튼 누르면 해당 질문에 맞는 답변을 조회
- [x] chip id에 해당하는 것이 없을 때 발생하는 에러 타입 정의 및 처리

### 🔍 리뷰 요청 사항
- 전체적인 API 응답 구조 및 Swagger 확인
- FAQChip은 `created_at`이나 `updated_at`이 필요하지 않고 `id` 또한 tsid를 적용하지 않고 auto increment (1, 2, 3, ...) id를 써도 된다고 판단하여 `BaseEntity`를 extends 하지 않고 auto increment id를 쓰는 걸로 구현함
- FAQChip은 DB에 넣어두고 쓸 것이기 때문에 조회 API만 구현함

### 📝 연관 이슈
> close #23 