### PR TITLE
[FEAT] #21 연령대별 요금제 랭킹 조회 API 구현

### DIFF
--- a/src/main/java/com/together/server/api/plan/RankingPlanController.java
+++ b/src/main/java/com/together/server/api/plan/RankingPlanController.java
@@ -1,0 +1,52 @@
+// 📁 com/together/server/api/ranking_plan/RankingPlanController.java
+package com.together.server.api.plan;
+
+import com.together.server.application.plan.RankingPlanService;
+import com.together.server.application.plan.response.RankingPlanListResponse;
+import com.together.server.infra.security.Accessor;
+import com.together.server.support.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * @author ihyeeun
+ * @see RankingPlanService
+ */
+@RestController
+@RequestMapping("/api/ranking-plans")
+@RequiredArgsConstructor
+@Tag(name = "요금제 랭킹", description = "연령대별 인기 요금제 랭킹 조회 API")
+public class RankingPlanController {
+
+    private final RankingPlanService rankingPlanService;
+
+    /**
+     * 연령대별 인기 요금제 랭킹을 조회합니다.
+     *
+     * @param ageGroup 조회할 연령대 (전체, 20대, 30대, 40대, 50대, 60대이상)
+     * @return 요금제 랭킹 목록 응답
+     * GET /api/ranking-plans?ageGroup=20대
+     * GET /api/ranking-plans (로그인 사용자의 연령대 맞춤 추천)
+     */
+    @GetMapping
+    @Operation(
+            summary = "인기 요금제 랭킹 조회",
+            description = "연령대별 인기 요금제 20개를 조회합니다.<br>" +
+                    "로그인이 되어있다면 사용자의 연령대에 해당하는 탭이 기본 선택되어 요금제가 조회되며,<br>" +
+                    "비로그인이라면 전체 탭이 기본 선택되어 보여집니다.<br>" +
+                    "[전체, 20대, 30대, 40대, 50대, 60대이상]"
+    )
+    public ResponseEntity<ApiResponse<RankingPlanListResponse>> getRankingPlans(@RequestParam(required = false) String ageGroup) {
+
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        Accessor accessor = (principal instanceof Accessor) ? (Accessor) principal : Accessor.GUEST;
+
+        RankingPlanListResponse response = rankingPlanService.getRankingPlans(accessor, ageGroup);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+}

--- a/src/main/java/com/together/server/application/plan/RankingPlanService.java
+++ b/src/main/java/com/together/server/application/plan/RankingPlanService.java
@@ -1,0 +1,74 @@
+package com.together.server.application.plan;
+
+import com.together.server.application.plan.response.RankingPlanListResponse;
+import com.together.server.application.plan.response.RankingPlanResponse;
+import com.together.server.domain.member.Member;
+import com.together.server.domain.member.MemberRepository;
+import com.together.server.domain.plan.RankingPlan;
+import com.together.server.domain.plan.RankingPlanRepository;
+import com.together.server.infra.security.Accessor;
+import com.together.server.support.error.CoreException;
+import com.together.server.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 요금제 랭킹 관련 비즈니스 로직을 처리하는 서비스 클래스입니다.
+ * @see RankingPlan
+ * @see RankingPlanResponse
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class RankingPlanService {
+
+    private final RankingPlanRepository rankingPlanRepository;
+    private final MemberRepository memberRepository;
+
+    /**
+     * 로그인 여부에 따라 연령대 기반 요금제 랭킹을 조회합니다.
+     *
+     * @param accessor 로그인 사용자 정보 (비로그인 시 guest 처리)
+     * @param ageGroup 선택된 연령대 탭 (null이면 사용자 연령대 사용)
+     * @return 요금제 랭킹 응답
+     */
+    public RankingPlanListResponse getRankingPlans(Accessor accessor, String ageGroup) {
+        boolean isGuest = (accessor == null || accessor.isGuest());
+        String userAgeGroup = null;
+
+        if (!isGuest) {
+            Member member = memberRepository.findByMemberId(accessor.id())
+                    .orElseThrow(() -> new CoreException(ErrorType.MEMBER_NOT_FOUND));
+
+            userAgeGroup = member.getAgeGroup();
+        }
+
+        String targetAgeGroup;
+        if (ageGroup != null) {
+            targetAgeGroup = ageGroup;
+        } else if (userAgeGroup != null) {
+            targetAgeGroup = userAgeGroup;
+        } else {
+            targetAgeGroup = "전체";
+        }
+
+
+        List<RankingPlan> plans = rankingPlanRepository.findByAgeGroupOrderByRank(targetAgeGroup);
+        List<RankingPlanResponse> responseList = plans.stream()
+                .map(RankingPlanResponse::new)
+                .collect(Collectors.toList());
+
+        return new RankingPlanListResponse(
+                targetAgeGroup,
+                !isGuest,
+                userAgeGroup,
+                responseList
+        );
+    }
+}

--- a/src/main/java/com/together/server/application/plan/response/RankingPlanListResponse.java
+++ b/src/main/java/com/together/server/application/plan/response/RankingPlanListResponse.java
@@ -1,0 +1,40 @@
+// 📁 com/together/server/application/plan/response/RankingPlanListResponse.java
+package com.together.server.application.plan.response;
+
+import lombok.Getter;
+import java.util.List;
+
+/**
+ * 요금제 목록과 메타 정보를 클라이언트에게 전달하는 응답 클래스입니다.
+ * @see RankingPlanResponse
+ */
+@Getter
+public class RankingPlanListResponse {
+
+    private final String currentAgeGroup;
+    private final boolean isLoggedIn;
+    private final String userAgeGroup;
+    private final int totalCount;
+    private final List<RankingPlanResponse> plans;
+
+    /**
+     * 요금제 목록 응답 객체를 생성합니다.
+     *
+     * @param currentAgeGroup 현재 조회한 연령대 (사용자가 클릭한 연령대)
+     * @param isLoggedIn 사용자 로그인 여부
+     * @param userAgeGroup 사용자의 연령대 (기본 탭 설정용)
+     * @param plans 요금제 목록
+     * @example
+     * List<RankingPlanResponse> planList = // 요금제 목록 생성
+     * RankingPlanListResponse response = new RankingPlanListResponse(
+     *     "20대", true, "20대", planList
+     * );
+     */
+    public RankingPlanListResponse(String currentAgeGroup, boolean isLoggedIn, String userAgeGroup, List<RankingPlanResponse> plans) {
+        this.currentAgeGroup = currentAgeGroup;
+        this.isLoggedIn = isLoggedIn;
+        this.userAgeGroup = userAgeGroup;
+        this.totalCount = plans.size();
+        this.plans = plans;
+    }
+}

--- a/src/main/java/com/together/server/application/plan/response/RankingPlanResponse.java
+++ b/src/main/java/com/together/server/application/plan/response/RankingPlanResponse.java
@@ -1,0 +1,65 @@
+// 📁 com/together/server/application/plan/response/RankingPlanResponse.java
+package com.together.server.application.plan.response;
+
+import com.together.server.domain.plan.RankingPlan;
+import lombok.Getter;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.Map;
+
+/**
+ * 개별 요금제 정보를 클라이언트에게 전달하는 응답 클래스입니다.
+ * @see RankingPlan
+ */
+@Getter
+public class RankingPlanResponse {
+
+    private final Integer id;
+    private final String ageGroupName;
+    private final Integer rank;
+    private final String name;
+    private final String description;
+    private final String regularPrice;
+    private final String dataAmount;
+    private final String sharedData;
+    private final String basicBenefits;
+    private final String smartDevice;
+    private final String speedLimit;
+    private final String targetTypes;
+    private final Map<String, String> allBenefits;
+
+    /**
+     * RankingPlan 엔티티를 RankingPlanResponse로 변환합니다.
+     *
+     * @param plan 변환할 RankingPlan 엔티티
+     * @example
+     * RankingPlan plan = repository.findById(1);
+     * RankingPlanResponse response = new RankingPlanResponse(plan);
+     */
+    public RankingPlanResponse(RankingPlan plan) {
+        this.id = plan.getId();
+        this.ageGroupName = plan.getAgeGroup();
+        this.rank = plan.getRank();
+        this.name = plan.getName();
+        this.description = plan.getDescription();
+        this.regularPrice = plan.getRegularPrice();
+        this.dataAmount = plan.getDataAmount();
+        this.sharedData = plan.getSharedData();
+        this.basicBenefits = plan.getBasicBenefits();
+        this.smartDevice = plan.getSmartDevice();
+        this.speedLimit = plan.getSpeedLimit();
+        this.targetTypes = plan.getTargetTypes();
+        this.allBenefits = parseAllBenefits(plan.getAllBenefits());
+    }
+
+    private Map<String, String> parseAllBenefits(String json) {
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            return mapper.readValue(json, new TypeReference<>() {});
+        } catch (Exception e) {
+            return Map.of(); // 파싱 실패 시 빈 맵 반환
+        }
+    }
+}

--- a/src/main/java/com/together/server/domain/plan/RankingPlan.java
+++ b/src/main/java/com/together/server/domain/plan/RankingPlan.java
@@ -1,0 +1,50 @@
+package com.together.server.domain.plan;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "ranking_plans")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RankingPlan {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Column(name = "age_group")
+    private String ageGroup;
+
+    @Column(name = "rank")
+    private Integer rank;
+
+    private String name;
+    private String description;
+
+    @Column(name = "regular_price")
+    private String regularPrice;
+
+    @Column(name = "data_amount")
+    private String dataAmount;
+
+    @Column(name = "shared_data")
+    private String sharedData;
+
+    @Column(name = "basic_benefits")
+    private String basicBenefits;
+
+    @Column(name = "smart_device")
+    private String smartDevice;
+
+    @Column(name = "speed_limit")
+    private String speedLimit;
+
+    @Column(name = "target_types")
+    private String targetTypes;
+
+    @Column(name = "all_benefits")
+    private String allBenefits;
+}

--- a/src/main/java/com/together/server/domain/plan/RankingPlanRepository.java
+++ b/src/main/java/com/together/server/domain/plan/RankingPlanRepository.java
@@ -1,0 +1,26 @@
+// 📁 com/together/server/domain/plan/RankingPlanRepository.java
+package com.together.server.domain.plan;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+/**
+ * 요금제 랭킹 데이터를 조회하는 저장소 인터페이스입니다.
+ * @see RankingPlan
+ */
+public interface RankingPlanRepository extends JpaRepository<RankingPlan, Integer> {
+
+    /**
+     * 특정 연령대의 요금제 목록을 랭킹 순으로 조회합니다.
+     *
+     * @param ageGroup 조회할 연령대
+     * @return 해당 연령대의 요금제 목록
+     * @example
+     * List<RankingPlan> plans = repository.findByAgeGroupOrderByRank("20대");
+     */
+    @Query("SELECT r FROM RankingPlan r WHERE r.ageGroup = :ageGroup ORDER BY r.rank ASC")
+    List<RankingPlan> findByAgeGroupOrderByRank(@Param("ageGroup") String ageGroup);
+}

--- a/src/main/java/com/together/server/infra/security/SecurityConfig.java
+++ b/src/main/java/com/together/server/infra/security/SecurityConfig.java
@@ -58,7 +58,8 @@ public class SecurityConfig {
                                 "/swagger-ui/index.html",
                                 "/swagger-resources/**",
                                 "/webjars/**",
-                                "/api/auth/login/kakao/**"
+                                "/api/auth/login/kakao/**",
+                                "/api/ranking-plans/**"
                         ).permitAll()
                         .anyRequest().authenticated())
                 .exceptionHandling(it -> it

--- a/src/main/java/com/together/server/infra/swagger/SwaggerConfig.java
+++ b/src/main/java/com/together/server/infra/swagger/SwaggerConfig.java
@@ -44,4 +44,13 @@ public class SwaggerConfig {
                 .pathsToMatch("/api/members/**")
                 .build();
     }
+
+    @Bean
+    public GroupedOpenApi rankingApi() {
+        return GroupedOpenApi.builder()
+                .group("ranking")
+                .pathsToMatch("/api/ranking-plans/**")
+                .build();
+    }
+
 }


### PR DESCRIPTION
### 🚀 작업 내용
- [ ] 연령대별 요금제 랭킹 조회 API 구현(DB에 있는 데이터 가져오게 구현)
- [ ] 로그인된 경우, 사용자의 연령대를 조회하게 구현
- [ ] 비로그인 사용자는 "전체" 연령대 기준 랭킹 조회

### 🔍 리뷰 요청 사항


### 📝 연관 이슈
close #21 