### PR TITLE
[FEAT] #28 스미싱 퀴즈 기능 구현

### DIFF
--- a/src/main/java/com/together/server/api/auth/AuthController.java
+++ b/src/main/java/com/together/server/api/auth/AuthController.java
@@ -11,6 +11,8 @@ import com.together.server.application.member.response.MemberInfoResponse;
 import com.together.server.infra.oauth.KakaoOAuthClient;
 import com.together.server.infra.security.Accessor;
 import com.together.server.infra.web.TokenCookieHandler;
+import com.together.server.support.error.CoreException;
+import com.together.server.support.error.ErrorType;
 import com.together.server.support.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletResponse;
@@ -51,8 +53,11 @@ public class AuthController {
 
     @PatchMapping("/firstLogin")
     @Operation(summary = "최초 로그인 추가 정보 입력", description = "최초 로그인 시 추가 정보 등록")
-    public ResponseEntity<ApiResponse<Void>> updateFirstLoginInfo(@RequestBody FirstLoginRequest request) {
-        Accessor accessor = (Accessor) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+    public ResponseEntity<ApiResponse<Void>> updateFirstLoginInfo(@RequestBody FirstLoginRequest request,
+                                                                  @AuthenticationPrincipal Accessor accessor) {
+        if (accessor.isGuest()) {
+            throw new CoreException(ErrorType.FORBIDDEN);
+        }
         String memberId = accessor.id();
         authService.updateFirstLoginInfo(memberId, request);
         return ResponseEntity.ok(ApiResponse.success(null));

--- a/src/main/java/com/together/server/api/member/MemberController.java
+++ b/src/main/java/com/together/server/api/member/MemberController.java
@@ -5,12 +5,13 @@ import com.together.server.application.member.request.UpdateMemberInfoRequest;
 import com.together.server.application.member.response.MemberInfoResponse;
 import com.together.server.application.member.response.UpdateMemberInfoResponse;
 import com.together.server.infra.security.Accessor;
+import com.together.server.support.error.CoreException;
+import com.together.server.support.error.ErrorType;
 import com.together.server.support.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -30,23 +31,28 @@ public class MemberController {
     @PatchMapping("/me")
     @Operation(summary = "회원 정보 수정", description = "사용자 닉네임, 요금제, 글씨 크기 수정")
     public ResponseEntity<ApiResponse<UpdateMemberInfoResponse>> updateMemberInfo(
+            @AuthenticationPrincipal Accessor accessor,
             @RequestBody UpdateMemberInfoRequest request
     ) {
-        Accessor accessor = (Accessor) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        if (accessor.isGuest()) {
+            throw new CoreException(ErrorType.FORBIDDEN);
+        }
+
         String memberId = accessor.id();
         UpdateMemberInfoResponse response = memberService.updateMemberInfo(memberId, request);
-
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     @DeleteMapping("/me")
     @Operation(summary = "회원 탈퇴", description = "사용자 탈퇴")
-    public ResponseEntity<ApiResponse<MemberInfoResponse>> deleteMember() {
-        Accessor accessor = (Accessor) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+    public ResponseEntity<ApiResponse<MemberInfoResponse>> deleteMember(
+            @AuthenticationPrincipal Accessor accessor
+    ) {
+        if (accessor.isGuest()) {
+            throw new CoreException(ErrorType.FORBIDDEN);
+        }
         String memberId = accessor.id();
-        MemberInfoResponse response = memberService.getMemberInfo(accessor.id());
         memberService.deleteMember(memberId);
-
         return ResponseEntity.ok(ApiResponse.success(null));
     }
 }

--- a/src/main/java/com/together/server/api/quiz/QuizController.java
+++ b/src/main/java/com/together/server/api/quiz/QuizController.java
@@ -1,0 +1,52 @@
+package com.together.server.api.quiz;
+
+import com.together.server.application.quiz.QuizService;
+import com.together.server.domain.quiz.Quiz;
+import com.together.server.infra.security.Accessor;
+import com.together.server.support.error.CoreException;
+import com.together.server.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/quiz")
+public class QuizController {
+    private final QuizService quizService;
+
+    @GetMapping("/random")
+    public ResponseEntity<Quiz> getRandomQuiz() {
+        return ResponseEntity.ok(quizService.getRandomQuiz());
+    }
+
+    @PostMapping("/submit")
+    public ResponseEntity<?> submitAnswer(
+            @RequestParam Long quizId,
+            @RequestParam boolean userAnswer,
+            @AuthenticationPrincipal Accessor accessor
+    ) {
+        if (accessor.isGuest()) {
+            throw new CoreException(ErrorType.FORBIDDEN);
+        }
+
+        Long memberId = Long.valueOf(accessor.id());
+        return ResponseEntity.ok(quizService.submitAnswer(quizId, memberId, userAnswer));
+    }
+
+    @GetMapping("/score")
+    public ResponseEntity<?> getScore(@AuthenticationPrincipal Accessor accessor) {
+        if (accessor.isGuest()) {
+            throw new CoreException(ErrorType.FORBIDDEN);
+        }
+
+        Long memberId = Long.valueOf(accessor.id());
+        return ResponseEntity.ok(Map.of("score", quizService.getTotalScore(memberId)));
+    }
+}
+

--- a/src/main/java/com/together/server/api/quiz/QuizController.java
+++ b/src/main/java/com/together/server/api/quiz/QuizController.java
@@ -7,9 +7,7 @@ import com.together.server.support.error.CoreException;
 import com.together.server.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;

--- a/src/main/java/com/together/server/application/auth/request/FirstLoginRequest.java
+++ b/src/main/java/com/together/server/application/auth/request/FirstLoginRequest.java
@@ -1,7 +1,7 @@
 package com.together.server.application.auth.request;
 
 public record FirstLoginRequest(
-    String ageGroup,
+    Integer ageGroup,
     String preferredPrice,
     Boolean fontMode
 ){}

--- a/src/main/java/com/together/server/application/chat/SmishingChatService.java
+++ b/src/main/java/com/together/server/application/chat/SmishingChatService.java
@@ -96,7 +96,6 @@ public class SmishingChatService {
         Disposable subscription = openAiChatClient.streamChatCompletion(promptForMessage)
                 .subscribe(
                         chunk -> {
-//                            System.out.println("OpenAI chunk received: [" + chunk + "]");
                             chunkBuffer.append(chunk);
 
                             if (chunk.endsWith(" ") || chunk.endsWith("\n")) {

--- a/src/main/java/com/together/server/application/quiz/QuizService.java
+++ b/src/main/java/com/together/server/application/quiz/QuizService.java
@@ -1,0 +1,68 @@
+package com.together.server.application.quiz;
+
+import com.together.server.domain.member.Member;
+import com.together.server.domain.member.MemberRepository;
+import com.together.server.domain.quiz.MemberScore;
+import com.together.server.domain.quiz.MemberScoreRepository;
+import com.together.server.domain.quiz.Quiz;
+import com.together.server.domain.quiz.QuizRepository;
+import com.together.server.support.error.CoreException;
+import com.together.server.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+@Service
+@RequiredArgsConstructor
+public class QuizService {
+
+    private final QuizRepository quizRepository;
+    private final MemberScoreRepository scoreRepository;
+    private final MemberRepository memberRepository;
+
+    public Quiz getRandomQuiz() {
+        List<Quiz> all = quizRepository.findAll();
+        if (all.isEmpty()) throw new RuntimeException("퀴즈가 없습니다.");
+        return all.get(new Random().nextInt(all.size()));
+    }
+
+    public Map<String, Object> submitAnswer(Long quizId, Long memberId, boolean userAnswer) {
+        Member member = memberRepository.findById(String.valueOf(memberId))
+                .orElseThrow(() -> new CoreException(ErrorType.MEMBER_NOT_FOUND));
+
+        Quiz quiz = quizRepository.findById(quizId)
+                .orElseThrow(() -> new RuntimeException("퀴즈 없음"));
+
+        boolean isCorrect = (quiz.isCorrectAnswer() == userAnswer);
+        String feedback = isCorrect ? quiz.getExplanationIfCorrect() : quiz.getExplanationIfWrong();
+
+        MemberScore score = scoreRepository.findByMemberId(memberId)
+                .orElseGet(() -> scoreRepository.save(new MemberScore(member)));
+
+        if (isCorrect) {
+            score.increaseScore(1); // 정답일 경우 점수 증가
+            scoreRepository.save(score);
+        }
+
+        return Map.of(
+                "isCorrect", isCorrect,
+                "message", feedback,
+                "totalScore", score.getTotalScore()
+        );
+    }
+
+    public int getTotalScore(Long memberId) {
+        Member member = memberRepository.findById(String.valueOf(memberId))
+                .orElseThrow(() -> new CoreException(ErrorType.MEMBER_NOT_FOUND));
+
+        return scoreRepository.findByMemberId(memberId)
+                .map(MemberScore::getTotalScore)
+                .orElse(0);
+    }
+
+}
+

--- a/src/main/java/com/together/server/application/quiz/QuizService.java
+++ b/src/main/java/com/together/server/application/quiz/QuizService.java
@@ -9,7 +9,6 @@ import com.together.server.domain.quiz.QuizRepository;
 import com.together.server.support.error.CoreException;
 import com.together.server.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -26,7 +25,7 @@ public class QuizService {
 
     public Quiz getRandomQuiz() {
         List<Quiz> all = quizRepository.findAll();
-        if (all.isEmpty()) throw new RuntimeException("퀴즈가 없습니다.");
+        if (all.isEmpty()) throw new CoreException(ErrorType.QUIZ_EMPTY);
         return all.get(new Random().nextInt(all.size()));
     }
 
@@ -35,7 +34,7 @@ public class QuizService {
                 .orElseThrow(() -> new CoreException(ErrorType.MEMBER_NOT_FOUND));
 
         Quiz quiz = quizRepository.findById(quizId)
-                .orElseThrow(() -> new RuntimeException("퀴즈 없음"));
+                .orElseThrow(() -> new CoreException(ErrorType.QUIZ_NOT_FOUND));
 
         boolean isCorrect = (quiz.isCorrectAnswer() == userAnswer);
         String feedback = isCorrect ? quiz.getExplanationIfCorrect() : quiz.getExplanationIfWrong();
@@ -44,7 +43,7 @@ public class QuizService {
                 .orElseGet(() -> scoreRepository.save(new MemberScore(member)));
 
         if (isCorrect) {
-            score.increaseScore(1); // 정답일 경우 점수 증가
+            score.increaseScore(1);
             scoreRepository.save(score);
         }
 

--- a/src/main/java/com/together/server/domain/member/Member.java
+++ b/src/main/java/com/together/server/domain/member/Member.java
@@ -24,7 +24,7 @@ public class Member extends BaseEntity {
     private String nickname;
 
     @Column(name = "age_group")
-    private String ageGroup;
+    private Integer ageGroup;
 
     @Column(name = "preferred_price")
     private String preferredPrice;
@@ -46,7 +46,7 @@ public class Member extends BaseEntity {
         this.delflag = false;
     }
 
-    public void updateFirstLoginInfo(String ageGroup, String preferredPrice, Boolean fontMode) {
+    public void updateFirstLoginInfo(Integer ageGroup, String preferredPrice, Boolean fontMode) {
         this.ageGroup = ageGroup;
         this.preferredPrice = preferredPrice;
         this.fontMode = String.valueOf(fontMode);

--- a/src/main/java/com/together/server/domain/member/validator/FirstLoginValidator.java
+++ b/src/main/java/com/together/server/domain/member/validator/FirstLoginValidator.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
 public class FirstLoginValidator {
 
     public void validate(FirstLoginRequest request) {
-        if (request.ageGroup() == null || request.ageGroup().trim().isEmpty()) {
+        if (request.ageGroup() == null) {
             throw new CoreException(ErrorType.REQUIRED_AGE_GROUP);
         }
         if (request.preferredPrice() == null || request.preferredPrice().trim().isEmpty()) {

--- a/src/main/java/com/together/server/domain/member/validator/RegisterValidator.java
+++ b/src/main/java/com/together/server/domain/member/validator/RegisterValidator.java
@@ -33,4 +33,5 @@ public class RegisterValidator {
         }
 
     }
+
 }

--- a/src/main/java/com/together/server/domain/quiz/MemberScore.java
+++ b/src/main/java/com/together/server/domain/quiz/MemberScore.java
@@ -1,0 +1,32 @@
+package com.together.server.domain.quiz;
+
+import com.together.server.domain.member.Member;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class MemberScore {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", referencedColumnName = "id", nullable = false)
+    private Member member;
+
+    @Column(nullable = false)
+    private int totalScore = 0;
+
+    public MemberScore(Member member) {
+        this.member = member;
+        this.totalScore = 0;
+    }
+
+    public void increaseScore(int point) {
+        this.totalScore += point;
+    }
+}

--- a/src/main/java/com/together/server/domain/quiz/MemberScoreRepository.java
+++ b/src/main/java/com/together/server/domain/quiz/MemberScoreRepository.java
@@ -1,0 +1,9 @@
+package com.together.server.domain.quiz;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberScoreRepository extends JpaRepository<MemberScore, Long> {
+    Optional<MemberScore> findByMemberId(Long memberId);
+}

--- a/src/main/java/com/together/server/domain/quiz/Quiz.java
+++ b/src/main/java/com/together/server/domain/quiz/Quiz.java
@@ -1,0 +1,36 @@
+package com.together.server.domain.quiz;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Quiz {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 1000)
+    private String message;
+
+    @Column(nullable = false)
+    private boolean correctAnswer; // true = 스미싱 문자
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String explanationIfCorrect;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String explanationIfWrong;
+
+    // 생성자
+    public Quiz(String message, boolean correctAnswer, String explanationIfCorrect, String explanationIfWrong) {
+        this.message = message;
+        this.correctAnswer = correctAnswer;
+        this.explanationIfCorrect = explanationIfCorrect;
+        this.explanationIfWrong = explanationIfWrong;
+    }
+}
+

--- a/src/main/java/com/together/server/domain/quiz/Quiz.java
+++ b/src/main/java/com/together/server/domain/quiz/Quiz.java
@@ -17,7 +17,7 @@ public class Quiz {
     private String message;
 
     @Column(nullable = false)
-    private boolean correctAnswer; // true = 스미싱 문자
+    private boolean correctAnswer;
 
     @Column(nullable = false, columnDefinition = "TEXT")
     private String explanationIfCorrect;
@@ -25,7 +25,6 @@ public class Quiz {
     @Column(nullable = false, columnDefinition = "TEXT")
     private String explanationIfWrong;
 
-    // 생성자
     public Quiz(String message, boolean correctAnswer, String explanationIfCorrect, String explanationIfWrong) {
         this.message = message;
         this.correctAnswer = correctAnswer;

--- a/src/main/java/com/together/server/domain/quiz/QuizRepository.java
+++ b/src/main/java/com/together/server/domain/quiz/QuizRepository.java
@@ -1,0 +1,5 @@
+package com.together.server.domain.quiz;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QuizRepository extends JpaRepository<Quiz, Long> {}

--- a/src/main/java/com/together/server/infra/swagger/SwaggerConfig.java
+++ b/src/main/java/com/together/server/infra/swagger/SwaggerConfig.java
@@ -52,4 +52,12 @@ public class SwaggerConfig {
                 .pathsToMatch("/api/templates/**")
                 .build();
     }
+
+    @Bean
+    public GroupedOpenApi QuizApi() {
+        return GroupedOpenApi.builder()
+                .group("quiz")
+                .pathsToMatch("/api/quiz/**")
+                .build();
+    }
 }

--- a/src/main/java/com/together/server/support/error/ErrorType.java
+++ b/src/main/java/com/together/server/support/error/ErrorType.java
@@ -47,8 +47,11 @@ public enum ErrorType {
     // 알림장
     NOTIFICATION_NOT_FOUND(40401, HttpStatus.NOT_FOUND, "해당 알림장이 없습니다.", LogLevel.WARN),
     INVALID_NOTIFICATION_TITLE(40402, HttpStatus.BAD_REQUEST, "알림장 제목은 비어 있을 수 없습니다.", LogLevel.WARN),
-    INVALID_NOTIFICATION_ISSUE_OR_SOLUTION(40403, HttpStatus.BAD_REQUEST, "알림장 이슈와 대응 방안은 비어 있을 수 없습니다.", LogLevel.WARN);
+    INVALID_NOTIFICATION_ISSUE_OR_SOLUTION(40403, HttpStatus.BAD_REQUEST, "알림장 이슈와 대응 방안은 비어 있을 수 없습니다.", LogLevel.WARN),
 
+    // 퀴즈
+    QUIZ_NOT_FOUND(40601, HttpStatus.BAD_REQUEST, "해당 퀴즈를 찾을 수 없습니다.", LogLevel.WARN),
+    QUIZ_EMPTY(40602, HttpStatus.BAD_REQUEST, "등록된 퀴즈가 없습니다.", LogLevel.WARN);
 
     public static final ErrorType SOCIAL_LOGIN_ONLY = null;
     private final int code;


### PR DESCRIPTION
### 🚀 작업 내용

- [x] 스미싱 퀴즈 기능 구현
- [x] memberController accessor 받아오는 형식으로 수정
- [x] 에러 타입  QUIZ_NOT_FOUND, QUIZ_EMPTY 추가
- [x] member_score 테이블 추가(사용자 별 누적 풀이 점수)
- [x] quiz 테이블 추가
- [x] /api/quiz/random, /api/quiz/submit, /api/quiz/score Api 추가

### 🔍 리뷰 요청 사항

random 퀴즈 요청 시

![image](https://github.com/user-attachments/assets/f1fce1a0-2c92-4cd9-83fc-03511f76006e)

퀴즈 풀이 요청 시

![image](https://github.com/user-attachments/assets/216ceb28-ee2a-4f0a-bc3c-540030c677cc)

사용자 별 적립 된 score

![image](https://github.com/user-attachments/assets/c2d5b580-ff05-4c41-aa40-cde254569d4c)


### 📝 연관 이슈

> close #28 