### PR TITLE
[FEAT] #38 로그인, 추가정보, 사용자 정보 API 수정

### DIFF
--- a/src/main/java/com/together/server/api/auth/AuthController.java
+++ b/src/main/java/com/together/server/api/auth/AuthController.java
@@ -5,10 +5,7 @@ import com.together.server.application.auth.KakaoService;
 import com.together.server.application.auth.request.FirstLoginRequest;
 import com.together.server.application.auth.request.LoginRequest;
 import com.together.server.application.auth.request.RegisterRequest;
-import com.together.server.application.auth.response.KakaoUserResponse;
-import com.together.server.application.auth.response.LoginResponse;
-import com.together.server.application.auth.response.LoginViewResponse;
-import com.together.server.application.auth.response.TokenResponse;
+import com.together.server.application.auth.response.*;
 import com.together.server.application.member.response.MemberInfoResponse;
 import com.together.server.infra.oauth.KakaoOAuthClient;
 import com.together.server.infra.security.Accessor;
@@ -67,17 +64,17 @@ public class AuthController {
 
     @GetMapping("/login/kakao")
     @Operation(summary = "카카오 로그인", description = "사용자 카카오 로그인으로 JWT 토큰 발급")
-    public ResponseEntity<ApiResponse<TokenResponse>> kakaoLogin(@RequestParam String code, HttpServletResponse response) {
+    public ResponseEntity<ApiResponse<LoginViewResponse>> kakaoLogin(@RequestParam String code, HttpServletResponse response) {
         String kakaoAccessToken = kakaoOAuthClient.getAccessToken(code);
         KakaoUserResponse kakaoUser = kakaoService.getKakaoUser(kakaoAccessToken);
-        TokenResponse token = authService.kakaoLogin(kakaoUser);
+        KakaoLoginResponse kakaoLogin = authService.kakaoLogin(kakaoUser);
 
-        ResponseCookie accessTokenCookie = tokenCookieHandler.createAccessTokenCookie(token.accessToken());
-        ResponseCookie refreshTokenCookie = tokenCookieHandler.createRefreshTokenCookie(token.refreshToken());
+        ResponseCookie accessTokenCookie = tokenCookieHandler.createAccessTokenCookie(kakaoLogin.accessToken());
+        ResponseCookie refreshTokenCookie = tokenCookieHandler.createRefreshTokenCookie(kakaoLogin.refreshToken());
 
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE, accessTokenCookie.toString(), refreshTokenCookie.toString())
-                .body(ApiResponse.success(token));
+                .body(ApiResponse.success(new LoginViewResponse(kakaoLogin.isFirstLogin())));
     }
 
 

--- a/src/main/java/com/together/server/api/auth/AuthController.java
+++ b/src/main/java/com/together/server/api/auth/AuthController.java
@@ -3,6 +3,7 @@ package com.together.server.api.auth;
 import com.together.server.application.auth.AuthService;
 import com.together.server.application.auth.KakaoService;
 import com.together.server.application.auth.request.FirstLoginRequest;
+import com.together.server.application.auth.request.KakaoCodeRequest;
 import com.together.server.application.auth.request.LoginRequest;
 import com.together.server.application.auth.request.RegisterRequest;
 import com.together.server.application.auth.response.*;
@@ -62,10 +63,13 @@ public class AuthController {
         return ResponseEntity.ok(ApiResponse.success(null));
     }
 
-    @GetMapping("/login/kakao")
-    @Operation(summary = "카카오 로그인", description = "사용자 카카오 로그인으로 JWT 토큰 발급")
-    public ResponseEntity<ApiResponse<LoginViewResponse>> kakaoLogin(@RequestParam String code, HttpServletResponse response) {
-        String kakaoAccessToken = kakaoOAuthClient.getAccessToken(code);
+    @PostMapping("/login/kakao")
+    @Operation(summary = "카카오 로그인", description = "클라이언트에서 받은 인가코드로 JWT 발급")
+    public ResponseEntity<ApiResponse<LoginViewResponse>> kakaoLogin(
+            @RequestBody KakaoCodeRequest request,
+            HttpServletResponse response
+    ) {
+        String kakaoAccessToken = kakaoOAuthClient.getAccessToken(request.code());
         KakaoUserResponse kakaoUser = kakaoService.getKakaoUser(kakaoAccessToken);
         KakaoLoginResponse kakaoLogin = authService.kakaoLogin(kakaoUser);
 

--- a/src/main/java/com/together/server/api/auth/AuthController.java
+++ b/src/main/java/com/together/server/api/auth/AuthController.java
@@ -6,6 +6,8 @@ import com.together.server.application.auth.request.FirstLoginRequest;
 import com.together.server.application.auth.request.LoginRequest;
 import com.together.server.application.auth.request.RegisterRequest;
 import com.together.server.application.auth.response.KakaoUserResponse;
+import com.together.server.application.auth.response.LoginResponse;
+import com.together.server.application.auth.response.LoginViewResponse;
 import com.together.server.application.auth.response.TokenResponse;
 import com.together.server.application.member.response.MemberInfoResponse;
 import com.together.server.infra.oauth.KakaoOAuthClient;
@@ -37,8 +39,8 @@ public class AuthController {
 
     @PostMapping("/login")
     @Operation(summary = "로그인", description = "사용자 로그인 처리 API")
-    public ResponseEntity<ApiResponse<Void>> login(@RequestBody LoginRequest request) {
-        TokenResponse response = authService.login(request);
+    public ResponseEntity<ApiResponse<LoginViewResponse>> login(@RequestBody LoginRequest request) {
+        LoginResponse response = authService.login(request);
 
         ResponseCookie accessTokenCookie = tokenCookieHandler.createAccessTokenCookie(response.accessToken());
         ResponseCookie refreshTokenCookie = tokenCookieHandler.createRefreshTokenCookie(response.refreshToken());
@@ -48,7 +50,7 @@ public class AuthController {
 
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE, accessTokenCookie.toString(), refreshTokenCookie.toString())
-                .body(ApiResponse.success(null));
+                .body(ApiResponse.success(new LoginViewResponse(response.isFirstLogin())));
     }
 
     @PatchMapping("/firstLogin")

--- a/src/main/java/com/together/server/application/auth/AuthService.java
+++ b/src/main/java/com/together/server/application/auth/AuthService.java
@@ -3,6 +3,7 @@ package com.together.server.application.auth;
 import com.together.server.application.auth.request.FirstLoginRequest;
 import com.together.server.application.auth.request.LoginRequest;
 import com.together.server.application.auth.request.RegisterRequest;
+import com.together.server.application.auth.response.LoginResponse;
 import com.together.server.application.member.request.UpdateMemberInfoRequest;
 import com.together.server.application.auth.response.KakaoUserResponse;
 import com.together.server.application.auth.response.MemberDetailsResponse;
@@ -41,7 +42,7 @@ public class AuthService {
     }
 
     @Transactional(readOnly = true)
-    public TokenResponse login(LoginRequest request) {
+    public LoginResponse login(LoginRequest request) {
         Member member = getByMemberId(request.memberId());
 
         if (!memberRepository.existsByMemberId(request.memberId())) {
@@ -63,7 +64,7 @@ public class AuthService {
         String accessToken = tokenProvider.createToken(member.getId().toString());
         String refreshToken = tokenProvider.createRefreshToken(member.getId().toString());
 
-        return new TokenResponse(accessToken, refreshToken);
+        return new LoginResponse(accessToken, refreshToken, member.getIsFirstLogin());
     }
 
     @Transactional

--- a/src/main/java/com/together/server/application/auth/AuthService.java
+++ b/src/main/java/com/together/server/application/auth/AuthService.java
@@ -4,7 +4,6 @@ import com.together.server.application.auth.request.FirstLoginRequest;
 import com.together.server.application.auth.request.LoginRequest;
 import com.together.server.application.auth.request.RegisterRequest;
 import com.together.server.application.auth.response.LoginResponse;
-import com.together.server.application.member.request.UpdateMemberInfoRequest;
 import com.together.server.application.auth.response.KakaoUserResponse;
 import com.together.server.application.auth.response.MemberDetailsResponse;
 import com.together.server.application.auth.response.TokenResponse;
@@ -141,11 +140,7 @@ public class AuthService {
         }
         firstLoginValidator.validate(request);
 
-        member.updateFirstLoginInfo(
-                request.ageGroup(),
-                request.preferredPrice(),
-                request.fontMode()
-        );
+        member.updateFirstLoginInfo(request.fontMode());
     }
 
 }

--- a/src/main/java/com/together/server/application/auth/AuthService.java
+++ b/src/main/java/com/together/server/application/auth/AuthService.java
@@ -3,10 +3,7 @@ package com.together.server.application.auth;
 import com.together.server.application.auth.request.FirstLoginRequest;
 import com.together.server.application.auth.request.LoginRequest;
 import com.together.server.application.auth.request.RegisterRequest;
-import com.together.server.application.auth.response.LoginResponse;
-import com.together.server.application.auth.response.KakaoUserResponse;
-import com.together.server.application.auth.response.MemberDetailsResponse;
-import com.together.server.application.auth.response.TokenResponse;
+import com.together.server.application.auth.response.*;
 import com.together.server.application.member.response.MemberInfoResponse;
 import com.together.server.domain.member.Member;
 import com.together.server.domain.member.MemberRepository;
@@ -89,7 +86,7 @@ public class AuthService {
     }
 
     @Transactional
-    public TokenResponse kakaoLogin(KakaoUserResponse kakaoUser) {
+    public KakaoLoginResponse kakaoLogin(KakaoUserResponse kakaoUser) {
         if (kakaoUser.email() == null || kakaoUser.nickname() == null) {
             throw new CoreException(ErrorType.KAKAO_USERINFO_INCOMPLETE);
         }
@@ -111,7 +108,7 @@ public class AuthService {
 
         String accessToken = tokenProvider.createToken(member.getId().toString());
         String refreshToken = tokenProvider.createRefreshToken(member.getId().toString());
-        return new TokenResponse(accessToken, refreshToken);
+        return new KakaoLoginResponse(accessToken, refreshToken, member.getIsFirstLogin());
     }
 
     @Transactional

--- a/src/main/java/com/together/server/application/auth/AuthService.java
+++ b/src/main/java/com/together/server/application/auth/AuthService.java
@@ -72,10 +72,9 @@ public class AuthService {
         Member savedMember = memberRepository.save(member);
 
         return new MemberInfoResponse(
-                savedMember.getId(),
                 savedMember.getMemberId(),
                 savedMember.getNickname(),
-                savedMember.getCreatedAt()
+                Boolean.TRUE.equals(savedMember.getFontMode())
         );
     }
 

--- a/src/main/java/com/together/server/application/auth/request/FirstLoginRequest.java
+++ b/src/main/java/com/together/server/application/auth/request/FirstLoginRequest.java
@@ -1,7 +1,6 @@
 package com.together.server.application.auth.request;
 
 public record FirstLoginRequest(
-    Integer ageGroup,
-    String preferredPrice,
-    Boolean fontMode
-){}
+        Boolean fontMode
+){
+}

--- a/src/main/java/com/together/server/application/auth/request/KakaoCodeRequest.java
+++ b/src/main/java/com/together/server/application/auth/request/KakaoCodeRequest.java
@@ -1,0 +1,5 @@
+package com.together.server.application.auth.request;
+
+public record KakaoCodeRequest(String code) {
+
+}

--- a/src/main/java/com/together/server/application/auth/response/KakaoLoginResponse.java
+++ b/src/main/java/com/together/server/application/auth/response/KakaoLoginResponse.java
@@ -1,8 +1,8 @@
 package com.together.server.application.auth.response;
 
-public record KakaoLoginResponse (
+public record KakaoLoginResponse(
         String accessToken,
         String refreshToken,
-        KakaoUserResponse user
-){
+        boolean isFirstLogin
+) {
 }

--- a/src/main/java/com/together/server/application/auth/response/LoginResponse.java
+++ b/src/main/java/com/together/server/application/auth/response/LoginResponse.java
@@ -1,0 +1,8 @@
+package com.together.server.application.auth.response;
+
+public record LoginResponse(
+        String accessToken,
+        String refreshToken,
+        boolean isFirstLogin
+) {
+}

--- a/src/main/java/com/together/server/application/auth/response/LoginViewResponse.java
+++ b/src/main/java/com/together/server/application/auth/response/LoginViewResponse.java
@@ -1,0 +1,6 @@
+package com.together.server.application.auth.response;
+
+public record LoginViewResponse(
+        boolean isFirstLogin
+) {
+}

--- a/src/main/java/com/together/server/application/member/MemberService.java
+++ b/src/main/java/com/together/server/application/member/MemberService.java
@@ -23,10 +23,9 @@ public class MemberService {
                 .orElseThrow(() -> new CoreException(ErrorType.MEMBER_NOT_FOUND));
 
         return new MemberInfoResponse(
-                member.getId(),
                 member.getMemberId(),
                 member.getNickname(),
-                member.getCreatedAt()
+                Boolean.TRUE.equals(member.getFontMode())
         );
     }
 
@@ -39,10 +38,6 @@ public class MemberService {
             member.updateNickname(request.nickname());
         }
 
-        if (request.preferredPrice() != null) {
-            member.updatePreferredPrice(request.preferredPrice());
-        }
-
         if (request.fontMode() != null) {
             member.updateFontMode(request.fontMode());
         }
@@ -50,9 +45,7 @@ public class MemberService {
         return new UpdateMemberInfoResponse(
                 member.getMemberId(),
                 member.getNickname(),
-                member.getPreferredPrice(),
-                member.getFontMode(),
-                member.getUpdatedAt()
+                member.getFontMode()
         );
     }
 

--- a/src/main/java/com/together/server/application/member/request/UpdateMemberInfoRequest.java
+++ b/src/main/java/com/together/server/application/member/request/UpdateMemberInfoRequest.java
@@ -2,7 +2,6 @@ package com.together.server.application.member.request;
 
 public record UpdateMemberInfoRequest(
         String nickname,
-        String preferredPrice,
-        String fontMode
+        Boolean fontMode
 ) {
 }

--- a/src/main/java/com/together/server/application/member/response/MemberInfoResponse.java
+++ b/src/main/java/com/together/server/application/member/response/MemberInfoResponse.java
@@ -3,9 +3,8 @@ package com.together.server.application.member.response;
 import java.time.Instant;
 
 public record MemberInfoResponse(
-        Long id,
         String memberId,
         String nickname,
-        Instant createdAt
+        boolean fontMode
 ) {
 }

--- a/src/main/java/com/together/server/application/member/response/UpdateMemberInfoResponse.java
+++ b/src/main/java/com/together/server/application/member/response/UpdateMemberInfoResponse.java
@@ -1,12 +1,9 @@
 package com.together.server.application.member.response;
 
-import java.time.Instant;
-
 public record UpdateMemberInfoResponse(
         String memberId,
         String nickname,
-        String preferredPrice,
-        String fontMode,
-        Instant updated_at
+        Boolean fontMode
 ) {
 }
+

--- a/src/main/java/com/together/server/domain/member/Member.java
+++ b/src/main/java/com/together/server/domain/member/Member.java
@@ -30,7 +30,7 @@ public class Member extends BaseEntity {
     private String preferredPrice;
 
     @Column(name = "font_mode")
-    private String fontMode;
+    private Boolean fontMode;
 
     @Column(name = "is_first_login", nullable = false)
     private Boolean isFirstLogin = true;
@@ -44,10 +44,12 @@ public class Member extends BaseEntity {
         this.password = password;
         this.isFirstLogin = true;
         this.delflag = false;
+        this.fontMode = false;
     }
 
+
     public void updateFirstLoginInfo(Boolean fontMode) {
-        this.fontMode = String.valueOf(fontMode);
+        this.fontMode = fontMode;
         this.isFirstLogin = false;
     }
 
@@ -59,7 +61,7 @@ public class Member extends BaseEntity {
         this.preferredPrice = preferredPrice;
     }
 
-    public void updateFontMode(String fontMode) {
+    public void updateFontMode(Boolean fontMode) {
         this.fontMode = fontMode;
     }
 

--- a/src/main/java/com/together/server/domain/member/Member.java
+++ b/src/main/java/com/together/server/domain/member/Member.java
@@ -46,9 +46,7 @@ public class Member extends BaseEntity {
         this.delflag = false;
     }
 
-    public void updateFirstLoginInfo(Integer ageGroup, String preferredPrice, Boolean fontMode) {
-        this.ageGroup = ageGroup;
-        this.preferredPrice = preferredPrice;
+    public void updateFirstLoginInfo(Boolean fontMode) {
         this.fontMode = String.valueOf(fontMode);
         this.isFirstLogin = false;
     }

--- a/src/main/java/com/together/server/domain/member/validator/FirstLoginValidator.java
+++ b/src/main/java/com/together/server/domain/member/validator/FirstLoginValidator.java
@@ -11,12 +11,6 @@ import org.springframework.stereotype.Component;
 public class FirstLoginValidator {
 
     public void validate(FirstLoginRequest request) {
-        if (request.ageGroup() == null) {
-            throw new CoreException(ErrorType.REQUIRED_AGE_GROUP);
-        }
-        if (request.preferredPrice() == null || request.preferredPrice().trim().isEmpty()) {
-            throw new CoreException(ErrorType.REQUIRED_PREFERRED_PRICE);
-        }
         if (request.fontMode() == null) {
             throw new CoreException(ErrorType.REQUIRED_FONT_MODE);
         }

--- a/src/main/java/com/together/server/infra/security/SecurityConfig.java
+++ b/src/main/java/com/together/server/infra/security/SecurityConfig.java
@@ -74,7 +74,7 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowedOrigins(List.of("http://localhost:5173"));
-        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setAllowCredentials(true);
 


### PR DESCRIPTION
### 🚀 작업 내용

- [x] 일반 로그인 및 소셜 로그인 요청 응답 수정
- [x] 추가 정보 입력 시 글씨 모드만 받도록 수정
- [x] 사용자 정보 조회, 수정 요청 및 응답 수정

### 🔍 리뷰 요청 사항
해당 과정이 올바르게 동작하는지 확인해 주시면 감사하겠습니다!
`
로그인 -> 로그인 요청 응답(처음 로그인 여부) 확인 -> 추가 정보 입력 -> 로그인 재요청 응답(처음 로그인 여부) 확인 -> 사용자 정보 조회 응답(전화번호, 이름, 글씨 모드) 확인 -> 사용자 정보 수정 -> 사용자 정보 조회 응답(수정사항) 확인
`

DB font_mode type을 string에서 boolean으로 수정하였습니다 (font_mode가 true일 경우 큰 글씨 모드입니다)

### 📝 연관 이슈

close https://github.com/Middle-Project-02/Together-Backend/issues/38