### PR TITLE
[FEAT] #45 푸시알림 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ out/
 .vscode/
 src/main/resources/application.yml
 node_modules
+
+### Firebase service account key
+src/main/resources/firebase/firebase-adminsdk.json

--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,9 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+    // firebase
+    implementation 'com.google.firebase:firebase-admin:9.2.0'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/together/server/api/member/MemberController.java
+++ b/src/main/java/com/together/server/api/member/MemberController.java
@@ -1,9 +1,11 @@
 package com.together.server.api.member;
 
 import com.together.server.application.member.MemberService;
+import com.together.server.application.member.request.FcmTokenRequest;
 import com.together.server.application.member.request.UpdateMemberInfoRequest;
 import com.together.server.application.member.response.MemberInfoResponse;
 import com.together.server.application.member.response.UpdateMemberInfoResponse;
+import com.together.server.domain.member.Member;
 import com.together.server.infra.security.Accessor;
 import com.together.server.support.error.CoreException;
 import com.together.server.support.error.ErrorType;
@@ -54,6 +56,12 @@ public class MemberController {
         String memberId = accessor.id();
         memberService.deleteMember(memberId);
         return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
+    @PostMapping("/api/members/fcm-token")
+    public ResponseEntity<Void> saveFcmToken(@RequestBody FcmTokenRequest request, @AuthenticationPrincipal Member member) {
+        member.updateFcmToken(request.fcmToken());
+        return ResponseEntity.ok().build();
     }
 }
 

--- a/src/main/java/com/together/server/application/member/request/FcmTokenRequest.java
+++ b/src/main/java/com/together/server/application/member/request/FcmTokenRequest.java
@@ -1,0 +1,3 @@
+package com.together.server.application.member.request;
+
+public record FcmTokenRequest(String fcmToken) { }

--- a/src/main/java/com/together/server/application/notification/NotificationService.java
+++ b/src/main/java/com/together/server/application/notification/NotificationService.java
@@ -3,9 +3,12 @@ package com.together.server.application.notification;
 import com.together.server.application.notification.request.NotificationCreateRequest;
 import com.together.server.application.notification.response.NotificationDetailResponse;
 import com.together.server.application.notification.response.NotificationSimpleResponse;
+import com.together.server.domain.member.Member;
+import com.together.server.domain.member.MemberRepository;
 import com.together.server.domain.notification.Notification;
 import com.together.server.domain.notification.NotificationRepository;
 import com.together.server.domain.notification.validator.NotificationCreateValidator;
+import com.together.server.infra.web.FcmService;
 import com.together.server.support.error.CoreException;
 import com.together.server.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
@@ -19,14 +22,25 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class NotificationService {
 
+    private final MemberRepository memberRepository;
     private final NotificationRepository notificationRepository;
     private final NotificationCreateValidator notificationCreateValidator;
+    private final FcmService fcmService;
 
     @Transactional
     public void createNotification(NotificationCreateRequest request) {
         notificationCreateValidator.validate(request);
         Notification notification = new Notification(request.title(), request.summary(), request.issue(), request.impact(), request.solution(), request.tags());
         notificationRepository.save(notification);
+
+        List<Member> membersWithToken = memberRepository.findByFcmTokenIsNotNull();
+        for (Member member : membersWithToken) {
+            fcmService.sendNotification(
+                    member.getFcmToken(),
+                    request.title(),
+                    request.summary()
+            );
+        }
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/together/server/config/FirebaseConfig.java
+++ b/src/main/java/com/together/server/config/FirebaseConfig.java
@@ -1,0 +1,30 @@
+package com.together.server.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import jakarta.annotation.PostConstruct;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+@Configuration
+public class FirebaseConfig {
+
+    @PostConstruct
+    public void initialize() {
+        if (FirebaseApp.getApps().isEmpty()) {
+            try (InputStream serviceAccount =
+                         getClass().getResourceAsStream("/firebase/firebase-adminsdk.json")) {
+
+                FirebaseOptions options = FirebaseOptions.builder()
+                        .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                        .build();
+                FirebaseApp.initializeApp(options);
+            } catch (Exception e) {
+                System.err.println("Firebase 초기화 실패: " + e.getMessage());
+            }
+        }
+    }
+}

--- a/src/main/java/com/together/server/domain/member/Member.java
+++ b/src/main/java/com/together/server/domain/member/Member.java
@@ -38,6 +38,9 @@ public class Member extends BaseEntity {
     @Column(name = "delflag", nullable = false)
     private Boolean delflag = false;
 
+    @Column(name = "fcm_token")
+    private String fcmToken;
+
     public Member(String memberId, String nickname, String password) {
         this.memberId = memberId;
         this.nickname = nickname;
@@ -73,4 +76,7 @@ public class Member extends BaseEntity {
         this.delflag = true;
     }
 
+    public void updateFcmToken(String fcmToken) {
+        this.fcmToken = fcmToken;
+    }
 }

--- a/src/main/java/com/together/server/domain/member/MemberRepository.java
+++ b/src/main/java/com/together/server/domain/member/MemberRepository.java
@@ -1,5 +1,6 @@
 package com.together.server.domain.member;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -8,4 +9,6 @@ public interface MemberRepository extends JpaRepository<Member, String> {
     Optional<Member> findByMemberId(String memberId);
 
     boolean existsByMemberId(String memberId);
+
+    List<Member> findByFcmTokenIsNotNull();
 }

--- a/src/main/java/com/together/server/infra/web/FcmService.java
+++ b/src/main/java/com/together/server/infra/web/FcmService.java
@@ -1,0 +1,26 @@
+package com.together.server.infra.web;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+import org.springframework.stereotype.Service;
+
+@Service
+public class FcmService {
+    public void sendNotification(String token, String title, String body) {
+        Message message = Message.builder()
+                .setToken(token)
+                .setNotification(Notification.builder()
+                        .setTitle(title)
+                        .setBody(body)
+                        .build())
+                .build();
+
+        try {
+            FirebaseMessaging.getInstance().send(message);
+        } catch (Exception e) {
+            System.err.println("FCM 메시지 전송 실패: " + e.getMessage());
+        }
+    }
+}
+


### PR DESCRIPTION
### 🚀 작업 내용
- [x] FCM(Firebase Cloud Messaging) 푸시 알림 기능 구현
- [x] Firebase Admin SDK 연동
- [x] FCM 토큰 관리 API 추가
- [x] 알림장 생성되면 FCM 토큰이 등록된 모든 사용자에게 자동 푸시 발송
- [x] Member 테이블에 fcm_token 컬럼 추가
![image](https://github.com/user-attachments/assets/e0ac40a4-82cd-4316-8320-f34dc7bd854d)
알림 내용은 좀 더 고민해서.. 수정하겠습니다🤔🤔

### 🔍 리뷰 요청 사항
- .gitignore에 추가된 firebase-adminsdk.json 파일은 노션에 추가해두겠습니다! 아래 사진처럼 경로 설정해주시면 됩니다!
<img width="225" alt="스크린샷 2025-06-24 오전 12 53 43" src="https://github.com/user-attachments/assets/2e44e198-9436-41f3-8985-2730c64e498e" />


### 📝 연관 이슈
> close #80